### PR TITLE
refactor: 승차권 엔티티 승차권 번호 관련 필드 이름 변경 (#28)

### DIFF
--- a/src/main/java/com/sudo/railo/ticket/domain/Ticket.java
+++ b/src/main/java/com/sudo/railo/ticket/domain/Ticket.java
@@ -51,15 +51,15 @@ public class Ticket {
     private TicketStatus status;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(255) COMMENT '승차권 발행 주체 코드 (웹, 모바일, 역 등 - 5자리)'")
-    private String wctNumber;
+    private String vendorCode;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(255) COMMENT '승차권 결제 일자 (MMdd)'")
-    private String saleAt;
+    private String purchaseDate;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(255) COMMENT '승차권 결제 순번 (10000~)'")
-    private String saleSeqNumber;
+    private String purchaseSeq;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(255) COMMENT '승차권 고유번호 (2자리)'")
-    private String pwd;
+    private String purchaseUid;
 
 }


### PR DESCRIPTION
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 나열해주세요. ex) - close #1 -->
- close #28

## 주요 변경 사항 (필수)
<!-- 변경사항을 나열해주세요. -->
- 승차권 엔티티의 승차권 번호 관련 필드 이름을 수정하였습니다.

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 작성해주세요. -->
- `wctNumber` -> `vendorCode` (발행 주체 코드)
- `saleAt` -> `purchaseDate`  
  (발매 일자, 발매는 결제 시점과 동일하게 이루어집니다. `purchase`를 사용했습니다.)  
  (그리고 'MMdd' 형식의 '일자'이기 때문에 `Date`를 사용했습니다.)
- `saleSeqNumber` -> `purchaseSeq` (발매 순번, 'Sequence'를 사용했습니다.)
- `pwd` -> `purchaseUid` (발매 고유번호, 'Unique Identifier'를 사용했습니다.)

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 작성해주세요. -->
아직 해당 엔티티의 필드를 참조하는 코드가 없어서 필드 이름만 바꿔둔 상태입니다.
앞으로 변경된 필드 이름을 사용해주시면 감사하겠습니다!

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.