### PR TITLE
[FEATURE] 회원번호 로그인 및 로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,11 @@ dependencies {
 
     /* JWT */
     // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     // https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-jackson
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
     /* QueryDSL */
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
@@ -64,7 +64,7 @@ tasks.named('test') {
 def querydslSrcDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
 
 sourceSets {
-    main.java.srcDirs += [ querydslSrcDir ]
+    main.java.srcDirs += [querydslSrcDir]
 }
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/sudo/railo/global/config/CorsConfig.java
+++ b/src/main/java/com/sudo/railo/global/config/CorsConfig.java
@@ -2,6 +2,7 @@ package com.sudo.railo.global.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -11,19 +12,23 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class CorsConfig {
 
+	@Value("${cors.allowed-origins}")
+	private String[] allowedOrigins;
+
+	@Value("${cors.allowed-methods}")
+	private String[] allowedMethods;
+
+	@Value("${cors.allowed-headers}")
+	private String[] allowedHeaders;
+
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
 
 		config.setAllowCredentials(true);
-		config.setAllowedOrigins(List.of("http://localhost:3000"));
-		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
-		config.setAllowedHeaders(List.of(
-			"Access-Control-Allow-Origin",
-			"Content-type",
-			"Access-Control-Allow-Headers",
-			"Authorization",
-			"X-Requested-With"));
+		config.setAllowedOrigins(List.of(allowedOrigins));
+		config.setAllowedMethods(List.of(allowedMethods));
+		config.setAllowedHeaders(List.of(allowedHeaders));
 
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/sudo/railo/global/config/CorsConfig.java
+++ b/src/main/java/com/sudo/railo/global/config/CorsConfig.java
@@ -1,0 +1,33 @@
+package com.sudo.railo.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration config = new CorsConfiguration();
+
+		config.setAllowCredentials(true);
+		config.setAllowedOrigins(List.of("http://localhost:3000"));
+		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+		config.setAllowedHeaders(List.of(
+			"Access-Control-Allow-Origin",
+			"Content-type",
+			"Access-Control-Allow-Headers",
+			"Authorization",
+			"X-Requested-With"));
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+		return source;
+	}
+
+}

--- a/src/main/java/com/sudo/railo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sudo/railo/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -17,6 +18,7 @@ import org.springframework.web.context.request.WebRequest;
 import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.global.exception.error.ErrorResponse;
 import com.sudo.railo.global.exception.error.GlobalError;
+import com.sudo.railo.global.security.TokenError;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
@@ -63,7 +65,8 @@ public class GlobalExceptionHandler {
 	 * @RequestParam 누락 처리 : MissingServletRequestParameterException
 	 */
 	@ExceptionHandler(MissingServletRequestParameterException.class)
-	public ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(MissingServletRequestParameterException ex) {
+	public ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(
+		MissingServletRequestParameterException ex) {
 		String detail = String.format("Required parameter '%s' is missing", ex.getParameterName());
 		ErrorResponse errorResponse = ErrorResponse.of(GlobalError.MISSING_REQUEST_PARAM, detail);
 
@@ -122,5 +125,15 @@ public class GlobalExceptionHandler {
 		} else {
 			log.warn("Business exception occurred: {}", ex.getMessage());
 		}
+	}
+
+	/*
+	 * 비밀번호 불일치 예외 처리
+	 * */
+	@ExceptionHandler(BadCredentialsException.class)
+	public ResponseEntity<ErrorResponse> handleBadCredentialsException(BadCredentialsException ex) {
+		ErrorResponse errorResponse = ErrorResponse.of(TokenError.INVALID_PASSWORD);
+		log.warn("Bad credentials: {}", ex.getMessage());
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
 	}
 }

--- a/src/main/java/com/sudo/railo/global/redis/LogoutRedis.java
+++ b/src/main/java/com/sudo/railo/global/redis/LogoutRedis.java
@@ -1,0 +1,19 @@
+package com.sudo.railo.global.redis;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
+public class LogoutRedis {
+
+	private String value; // "logout"
+	private Long expireTime; // 토큰 만료 시간
+}

--- a/src/main/java/com/sudo/railo/global/redis/MemberRedis.java
+++ b/src/main/java/com/sudo/railo/global/redis/MemberRedis.java
@@ -2,16 +2,20 @@ package com.sudo.railo.global.redis;
 
 import org.springframework.data.redis.core.RedisHash;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@RedisHash(value = "MemberToken", timeToLive = 3600 * 24 * 14)
+@RedisHash(value = "MemberToken", timeToLive = 3600 * 24 * 7)
 @Getter
 @Setter
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public class MemberRedis {
 
 	@Id

--- a/src/main/java/com/sudo/railo/global/redis/RedisConfig.java
+++ b/src/main/java/com/sudo/railo/global/redis/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -34,13 +35,26 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String, Object> redisTemplate() {
+	public RedisTemplate<String, String> customStringRedisTemplate() {
 
-		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+		return redisTemplate;
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> customObjectRedisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+		redisTemplate.setDefaultSerializer(serializer);
+		redisTemplate.setValueSerializer(serializer);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
 
 		return redisTemplate;
 	}

--- a/src/main/java/com/sudo/railo/global/redis/RedisError.java
+++ b/src/main/java/com/sudo/railo/global/redis/RedisError.java
@@ -1,0 +1,21 @@
+package com.sudo.railo.global.redis;
+
+import org.springframework.http.HttpStatus;
+
+import com.sudo.railo.global.exception.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisError implements ErrorCode {
+
+	REDIS_CONNECT_FAIL("Redis 서버 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "R_001"),
+	SERIALIZATION_FAIL("Json data 직렬화/역직렬화에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "R_002"),
+	INVALID_DATA_ACCESS("잘못된 Redis API 사용입니다.", HttpStatus.BAD_REQUEST, "R_003");
+
+	private final String message;
+	private final HttpStatus status;
+	private final String code;
+}

--- a/src/main/java/com/sudo/railo/global/redis/RedisUtil.java
+++ b/src/main/java/com/sudo/railo/global/redis/RedisUtil.java
@@ -1,17 +1,72 @@
 package com.sudo.railo.global.redis;
 
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisUtil {
 
-	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisTemplate<String, Object> objectRedisTemplate;
+	private final RedisTemplate<String, String> stringRedisTemplate;
 
 	public void save(String key, String value) {
-		redisTemplate.opsForValue().set(key, value);
+		stringRedisTemplate.opsForValue().set(key, value);
 	}
+
+	// Redis 키 값 증가
+	public Long increment(String key) {
+		return stringRedisTemplate.opsForValue().increment(key);
+	}
+
+	// Redis 키 만료 시간 설정
+	public void expireAt(String key, Instant expireTime) {
+		stringRedisTemplate.expireAt(key, expireTime);
+	}
+
+	// Member 리프레시 토큰 저장
+	public void saveMemberToken(MemberRedis memberRedis) {
+		objectRedisTemplate.opsForValue().set(memberRedis.getMemberNo(), memberRedis);
+	}
+
+	// 리프레시 토큰 조회
+	public String getRefreshToken(String memberNo) {
+		try {
+			MemberRedis memberRedis = (MemberRedis)objectRedisTemplate.opsForValue().get(memberNo);
+
+			if (memberRedis == null) {
+				log.warn("memberNo : {} 멤버 정보를 찾을 수 없습니다.", memberNo);
+				return null;
+			}
+
+			return memberRedis.getRefreshToken();
+		} catch (Exception e) {
+			log.error("getRefreshToken error : {}", e.getMessage());
+			return null;
+		}
+	}
+
+	// 리프레시 토큰 삭제
+	public void deleteRefreshToken(String memberNo) {
+		objectRedisTemplate.delete(memberNo);
+	}
+
+	// 로그아웃 토큰 정보 저장
+	public void saveLogoutToken(String accessToken, LogoutRedis logoutRedis, Long expireTime) {
+		objectRedisTemplate.opsForValue().set(accessToken, logoutRedis, expireTime, TimeUnit.MILLISECONDS);
+	}
+
+	// 로그아웃 토큰 정보 조회
+	public LogoutRedis getLogoutToken(String accessToken) {
+		Object value = objectRedisTemplate.opsForValue().get(accessToken);
+		return (LogoutRedis)value;
+	}
+
 }

--- a/src/main/java/com/sudo/railo/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/sudo/railo/global/security/CustomUserDetailsService.java
@@ -1,0 +1,46 @@
+package com.sudo.railo.global.security;
+
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import com.sudo.railo.global.exception.error.BusinessException;
+import com.sudo.railo.member.domain.Member;
+import com.sudo.railo.member.exception.MemberError;
+import com.sudo.railo.member.infra.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String memberNo) {
+		log.info("memberNo : {}", memberNo);
+		return memberRepository.findByMemberNo(memberNo)
+			.map(this::createUserDetails)
+			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
+	}
+
+	// userDetails 객체로 만들어 리턴
+	private UserDetails createUserDetails(Member member) {
+
+		GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getRole().name());
+
+		return new User(
+			member.getMemberDetail().getMemberNo(),
+			member.getPassword(),
+			Collections.singleton(grantedAuthority)
+		);
+	}
+}

--- a/src/main/java/com/sudo/railo/global/security/TokenError.java
+++ b/src/main/java/com/sudo/railo/global/security/TokenError.java
@@ -14,7 +14,8 @@ public enum TokenError implements ErrorCode {
 	INVALID_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_001"),
 	INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_002"),
 	LOGOUT_ERROR("로그아웃: 토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_003"),
-	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "T_004");
+	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "T_004"),
+	INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_005");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/railo/global/security/TokenError.java
+++ b/src/main/java/com/sudo/railo/global/security/TokenError.java
@@ -15,7 +15,8 @@ public enum TokenError implements ErrorCode {
 	INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_002"),
 	LOGOUT_ERROR("로그아웃: 토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_003"),
 	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "T_004"),
-	INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_005");
+	INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_005"),
+	AUTHORITY_NOT_FOUND("권한 정보가 없는 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_006");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/railo/global/security/TokenError.java
+++ b/src/main/java/com/sudo/railo/global/security/TokenError.java
@@ -1,0 +1,22 @@
+package com.sudo.railo.global.security;
+
+import org.springframework.http.HttpStatus;
+
+import com.sudo.railo.global.exception.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenError implements ErrorCode {
+
+	INVALID_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_001"),
+	INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_002"),
+	LOGOUT_ERROR("로그아웃: 토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_003"),
+	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "T_004");
+
+	private final String message;
+	private final HttpStatus status;
+	private final String code;
+}

--- a/src/main/java/com/sudo/railo/global/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,24 @@
+package com.sudo.railo.global.security.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+// Spring Security Filter Chain에서 접근 거부 발생 시 실행되는 핸들러
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AccessDeniedException accessDeniedException
+	) throws IOException {
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+	}
+}

--- a/src/main/java/com/sudo/railo/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.sudo.railo.global.security.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+// Spring Security Filter Chain에서 인증 실패 시 실행되는 핸들러.
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException {
+		response.sendError(HttpServletResponse.SC_FORBIDDEN);
+	}
+}

--- a/src/main/java/com/sudo/railo/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/JwtFilter.java
@@ -1,0 +1,66 @@
+package com.sudo.railo.global.security.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.sudo.railo.global.exception.error.BusinessException;
+import com.sudo.railo.global.redis.RedisUtil;
+import com.sudo.railo.global.security.TokenError;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+// JWT 토큰을 검사하여 유효성을 확인하고, 유효한 경우 인증 정보를 설정하는 역할을 수행
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String BEARER_PREFIX = "Bearer";
+	private final TokenProvider tokenProvider;
+	private final RedisUtil redisUtil;
+
+	// 각 요청에 대해 JWT 토큰을 검사하고 유효한 경우 SecurityContext에 인증 정보를 설정
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+
+		String jwt = resolveToken(request);
+
+		if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+
+			// 블랙리스트 형식으로 redis 에 해당 accessToken logout 여부 확인
+			Object isLogout = redisUtil.getLogoutToken(jwt);
+
+			// 로그아웃이 되어 있지 않은 경우 토큰 정상 작동
+			if (ObjectUtils.isEmpty(isLogout)) {
+				Authentication authentication = tokenProvider.getAuthentication(jwt);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			} else {
+				throw new BusinessException(TokenError.ALREADY_LOGOUT);
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(7);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
@@ -139,6 +139,7 @@ public class TokenProvider {
 			.getSubject();
 	}
 
+	// accessToken 유효 시간 추출
 	public Long getAccessTokenExpiration(String accessToken) {
 
 		Claims claims = parseClaims(accessToken);
@@ -155,7 +156,7 @@ public class TokenProvider {
 		Claims claims = parseClaims(accessToken);
 
 		if (claims.get(AUTHORITIES_KEY) == null) {
-			throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+			throw new BusinessException(TokenError.AUTHORITY_NOT_FOUND);
 		}
 
 		// 클레임에서 권한 정보 가져오기

--- a/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
@@ -179,13 +179,13 @@ public class TokenProvider {
 				.parseClaimsJws(token);
 			return true;
 		} catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-			log.info("잘못된 JWT 서명입니다.");
+			log.error("잘못된 JWT 서명입니다.");
 		} catch (ExpiredJwtException e) {
-			log.info("만료된 JWT 토큰입니다.");
+			log.error("만료된 JWT 토큰입니다.");
 		} catch (UnsupportedJwtException e) {
-			log.info("지원되지 않는 JWT 토큰입니다.");
+			log.error("지원되지 않는 JWT 토큰입니다.");
 		} catch (IllegalArgumentException e) {
-			log.info("JWT 토큰이 잘못되었습니다.");
+			log.error("JWT 토큰이 잘못되었습니다.");
 		}
 		return false;
 	}

--- a/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
@@ -1,0 +1,206 @@
+package com.sudo.railo.global.security.jwt;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import com.sudo.railo.global.exception.error.BusinessException;
+import com.sudo.railo.global.redis.MemberRedis;
+import com.sudo.railo.global.redis.RedisUtil;
+import com.sudo.railo.global.security.TokenError;
+import com.sudo.railo.member.application.dto.response.TokenResponse;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class TokenProvider {
+
+	private static final String AUTHORITIES_KEY = "auth";
+	private static final String BEARER_TYPE = "Bearer";
+	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
+	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+	private final Key key;
+	private final RedisUtil redisUtil;
+
+	public TokenProvider(
+		@Value("${jwt.secret}") String secretKey, RedisUtil redisUtil
+	) {
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+		this.redisUtil = redisUtil;
+	}
+
+	// 토큰 생성 메서드
+	public TokenResponse generateTokenDTO(Authentication authentication) {
+
+		// 권한들 가져오기
+		String authorities = authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
+
+		String accessToken = generateAccessToken(authentication.getName(), authorities);
+		String refreshToken = generateRefreshToken(authentication.getName(), authorities);
+
+		long now = System.currentTimeMillis();
+		Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+
+		return new TokenResponse(
+			BEARER_TYPE,
+			accessToken,
+			accessTokenExpiresIn.getTime(),
+			refreshToken
+		);
+	}
+
+	private String generateAccessToken(String memberNo, String authorities) {
+		long now = System.currentTimeMillis();
+		Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setSubject(memberNo)
+			.claim(AUTHORITIES_KEY, authorities)
+			.setExpiration(accessTokenExpiresIn)
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	private String generateRefreshToken(String memberNo, String authorities) {
+		long now = System.currentTimeMillis();
+		Date refreshTokenExpiresIn = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setSubject(memberNo)
+			.claim(AUTHORITIES_KEY, authorities)
+			.setExpiration(refreshTokenExpiresIn)
+			.claim("isRefreshToken", true) // refreshToken 임을 나타내는 클레임 추가
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	public TokenResponse reissueAccessToken(String refreshToken) {
+
+		// 리프레시 토큰에서 사용자 정보 추출 -> 클레임 확인
+		Claims claims = parseClaims(refreshToken);
+
+		// Refresh Token 검증 및 클레임에서 Refresh Token 여부 확인
+		if (!validateToken(refreshToken) || claims.get("isRefreshToken") == null || !Boolean.TRUE.equals(
+			claims.get("isRefreshToken"))) {
+			throw new BusinessException(TokenError.INVALID_REFRESH_TOKEN);
+		}
+
+		String memberNo = claims.getSubject();
+		String authorities = claims.get(AUTHORITIES_KEY).toString();
+
+		String newAccessToken = generateAccessToken(memberNo, authorities);
+		String newRefreshToken = generateRefreshToken(memberNo, authorities);
+
+		MemberRedis memberRedis = new MemberRedis(memberNo, newRefreshToken);
+		redisUtil.saveMemberToken(memberRedis);
+
+		long now = System.currentTimeMillis();
+		Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+
+		return new TokenResponse(
+			BEARER_TYPE,
+			newAccessToken,
+			accessTokenExpiresIn.getTime(),
+			newRefreshToken
+		);
+	}
+
+	// 토큰에 등록된 클레임의 sub에서 해당 회원 번호 추출
+	public String getMemberNo(String accessToken) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(accessToken)
+			.getBody()
+			.getSubject();
+	}
+
+	public Long getAccessTokenExpiration(String accessToken) {
+
+		Claims claims = parseClaims(accessToken);
+
+		Date expiration = claims.getExpiration();
+
+		// 현재시간 기준으로 남은 유효시간 계산
+		return expiration.getTime() - System.currentTimeMillis();
+	}
+
+	// AccessToken으로 인증 객체 추출
+	public Authentication getAuthentication(String accessToken) {
+
+		Claims claims = parseClaims(accessToken);
+
+		if (claims.get(AUTHORITIES_KEY) == null) {
+			throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+		}
+
+		// 클레임에서 권한 정보 가져오기
+		Collection<? extends GrantedAuthority> authorities =
+			Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
+
+		UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+		return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+	}
+
+	// 토큰 유효성 검사
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token);
+			return true;
+		} catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+			log.info("잘못된 JWT 서명입니다.");
+		} catch (ExpiredJwtException e) {
+			log.info("만료된 JWT 토큰입니다.");
+		} catch (UnsupportedJwtException e) {
+			log.info("지원되지 않는 JWT 토큰입니다.");
+		} catch (IllegalArgumentException e) {
+			log.info("JWT 토큰이 잘못되었습니다.");
+		}
+		return false;
+	}
+
+	// AccessToken에서 클레임을 추출하는 메서드
+	private Claims parseClaims(String accessToken) {
+		try {
+			return Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(accessToken)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			// 토큰이 만료되어 예외가 발생하더라도 클레임 값들은 뽑을 수 있음
+			return e.getClaims();
+		}
+	}
+
+}

--- a/src/main/java/com/sudo/railo/global/security/util/SecurityUtil.java
+++ b/src/main/java/com/sudo/railo/global/security/util/SecurityUtil.java
@@ -1,0 +1,23 @@
+package com.sudo.railo.global.security.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.sudo.railo.global.exception.error.BusinessException;
+import com.sudo.railo.global.security.TokenError;
+
+public class SecurityUtil {
+
+	private static Authentication getAuthentication() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || authentication.getName() == null) {
+			throw new BusinessException(TokenError.INVALID_TOKEN);
+		}
+		return authentication;
+	}
+
+	public static String getCurrentMemberNo() {
+		Authentication authentication = getAuthentication();
+		return authentication.getName();
+	}
+}

--- a/src/main/java/com/sudo/railo/member/application/MemberAuthService.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberAuthService.java
@@ -1,9 +1,17 @@
 package com.sudo.railo.member.application;
 
+import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
+import com.sudo.railo.member.application.dto.request.TokenRequest;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
+import com.sudo.railo.member.application.dto.response.TokenResponse;
 
 public interface MemberAuthService {
 
 	SignUpResponse signUp(SignUpRequest request);
+
+	TokenResponse memberNoLogin(MemberNoLoginRequest request);
+
+	void logout(TokenRequest request);
+
 }

--- a/src/main/java/com/sudo/railo/member/application/MemberAuthServiceImpl.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberAuthServiceImpl.java
@@ -16,7 +16,6 @@ import com.sudo.railo.global.redis.MemberRedis;
 import com.sudo.railo.global.redis.RedisUtil;
 import com.sudo.railo.global.security.TokenError;
 import com.sudo.railo.global.security.jwt.TokenProvider;
-import com.sudo.railo.global.security.util.SecurityUtil;
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
 import com.sudo.railo.member.application.dto.request.TokenRequest;
@@ -87,8 +86,6 @@ public class MemberAuthServiceImpl implements MemberAuthService {
 		if (!tokenProvider.validateToken(request.accessToken())) {
 			throw new BusinessException(TokenError.LOGOUT_ERROR);
 		}
-
-		System.out.println(SecurityUtil.getCurrentMemberNo());
 
 		// AccessToken 에서 memberNo 를 가져옴
 		Authentication authentication = tokenProvider.getAuthentication(request.accessToken());

--- a/src/main/java/com/sudo/railo/member/application/MemberAuthServiceImpl.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberAuthServiceImpl.java
@@ -3,13 +3,25 @@ package com.sudo.railo.member.application;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sudo.railo.global.exception.error.BusinessException;
+import com.sudo.railo.global.redis.LogoutRedis;
+import com.sudo.railo.global.redis.MemberRedis;
+import com.sudo.railo.global.redis.RedisUtil;
+import com.sudo.railo.global.security.TokenError;
+import com.sudo.railo.global.security.jwt.TokenProvider;
+import com.sudo.railo.global.security.util.SecurityUtil;
+import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
+import com.sudo.railo.member.application.dto.request.TokenRequest;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
+import com.sudo.railo.member.application.dto.response.TokenResponse;
 import com.sudo.railo.member.domain.Member;
 import com.sudo.railo.member.domain.MemberDetail;
 import com.sudo.railo.member.domain.Membership;
@@ -26,6 +38,9 @@ public class MemberAuthServiceImpl implements MemberAuthService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final MemberNoGenerator memberNoGenerator;
+	private final AuthenticationManagerBuilder authenticationManagerBuilder;
+	private final TokenProvider tokenProvider;
+	private final RedisUtil redisUtil;
 
 	@Override
 	@Transactional
@@ -46,6 +61,47 @@ public class MemberAuthServiceImpl implements MemberAuthService {
 		memberRepository.save(member);
 
 		return new SignUpResponse(memberNo);
+	}
+
+	@Override
+	@Transactional
+	public TokenResponse memberNoLogin(MemberNoLoginRequest request) {
+
+		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+			request.memberNo(), request.password());
+
+		Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+		TokenResponse tokenResponse = tokenProvider.generateTokenDTO(authentication);
+
+		// 레디스에 리프레시 토큰 저장
+		MemberRedis memberRedis = new MemberRedis(request.memberNo(), tokenResponse.refreshToken());
+		redisUtil.saveMemberToken(memberRedis);
+
+		return tokenResponse;
+	}
+
+	@Override
+	@Transactional
+	public void logout(TokenRequest request) {
+		// 로그아웃 하고 싶은 토큰이 유효한지 먼저 검증
+		if (!tokenProvider.validateToken(request.accessToken())) {
+			throw new BusinessException(TokenError.LOGOUT_ERROR);
+		}
+
+		System.out.println(SecurityUtil.getCurrentMemberNo());
+
+		// AccessToken 에서 memberNo 를 가져옴
+		Authentication authentication = tokenProvider.getAuthentication(request.accessToken());
+
+		// Redis 에서 해당 memberNo 로 저장된 RefreshToken 이 있는지 여부 확인 후, 존재할 경우 삭제
+		if (redisUtil.getRefreshToken(authentication.getName()) != null) {
+			redisUtil.deleteRefreshToken(authentication.getName());
+		}
+
+		// 해당 AccessToken 유효 시간을 가져와 BlackList 에 저장
+		Long expiration = tokenProvider.getAccessTokenExpiration(request.accessToken());
+		LogoutRedis logoutRedis = new LogoutRedis("logout", expiration);
+		redisUtil.saveLogoutToken(request.accessToken(), logoutRedis, expiration);
 	}
 
 }

--- a/src/main/java/com/sudo/railo/member/application/MemberNoGenerator.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberNoGenerator.java
@@ -7,8 +7,9 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+
+import com.sudo.railo.global.redis.RedisUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,22 +18,22 @@ import lombok.RequiredArgsConstructor;
 public class MemberNoGenerator {
 
 	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
-
-	private final StringRedisTemplate redisTemplate;
 	private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+	private final RedisUtil redisUtil;
 
 	public String generateMemberNo() {
 		String today = LocalDate.now().format(DATE_FORMATTER);
-		String redisKey = "memberNo:" + today;
+		String redisKey = "todayKey:" + today;
 
-		Long counter = redisTemplate.opsForValue().increment(redisKey);
+		Long counter = redisUtil.increment(redisKey);
 
 		// 자정까지 남은 시간 계산
 		ZonedDateTime midnightToday = ZonedDateTime.of(LocalDate.now(ZONE_ID), LocalTime.MAX, ZONE_ID);
 		Instant midnightInstant = midnightToday.toInstant();
 
 		// 자정 만료
-		redisTemplate.expireAt(redisKey, midnightInstant);
+		redisUtil.expireAt(redisKey, midnightInstant);
 
 		String paddedCounter = String.format("%04d", counter);
 

--- a/src/main/java/com/sudo/railo/member/application/dto/request/MemberNoLoginRequest.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/request/MemberNoLoginRequest.java
@@ -1,0 +1,13 @@
+package com.sudo.railo.member.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberNoLoginRequest(
+
+	@NotBlank(message = "회원번호는 필수입니다.")
+	String memberNo,
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	String password
+) {
+}

--- a/src/main/java/com/sudo/railo/member/application/dto/request/TokenRequest.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/request/TokenRequest.java
@@ -1,0 +1,13 @@
+package com.sudo.railo.member.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRequest(
+
+	@NotBlank(message = "accessToken 값은 필수입니다.")
+	String accessToken,
+
+	@NotBlank(message = "refreshToken 값은 필수입니다.")
+	String refreshToken
+) {
+}

--- a/src/main/java/com/sudo/railo/member/application/dto/response/TokenResponse.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/response/TokenResponse.java
@@ -1,0 +1,10 @@
+package com.sudo.railo.member.application.dto.response;
+
+public record TokenResponse(
+
+	String grantType,          // 토큰 타입
+	String accessToken,        // 액세스 토큰
+	Long accessTokenExpiresIn, // 만료 시간
+	String refreshToken        // 리프레시 토큰
+) {
+}

--- a/src/main/java/com/sudo/railo/member/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/member/presentation/AuthController.java
@@ -7,8 +7,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.member.application.MemberAuthService;
+import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
+import com.sudo.railo.member.application.dto.request.TokenRequest;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
+import com.sudo.railo.member.application.dto.response.TokenResponse;
 import com.sudo.railo.member.success.AuthSuccess;
 
 import jakarta.validation.Valid;
@@ -27,6 +30,22 @@ public class AuthController {
 		SignUpResponse response = memberAuthService.signUp(request);
 
 		return SuccessResponse.of(AuthSuccess.SIGN_UP_SUCCESS, response);
+	}
+
+	@PostMapping("/login")
+	public SuccessResponse<TokenResponse> memberNoLogin(@RequestBody @Valid MemberNoLoginRequest request) {
+
+		TokenResponse tokenResponse = memberAuthService.memberNoLogin(request);
+
+		return SuccessResponse.of(AuthSuccess.MEMBER_NO_LOGIN_SUCCESS, tokenResponse);
+	}
+
+	@PostMapping("/logout")
+	public SuccessResponse<?> logout(@RequestBody @Valid TokenRequest request) {
+
+		memberAuthService.logout(request);
+
+		return SuccessResponse.of(AuthSuccess.LOGOUT_SUCCESS);
 	}
 
 }

--- a/src/main/java/com/sudo/railo/member/success/AuthSuccess.java
+++ b/src/main/java/com/sudo/railo/member/success/AuthSuccess.java
@@ -11,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuthSuccess implements SuccessCode {
 
-	SIGN_UP_SUCCESS(HttpStatus.CREATED, "회원가입이 성공적으로 완료되었습니다.");
+	SIGN_UP_SUCCESS(HttpStatus.CREATED, "회원가입이 성공적으로 완료되었습니다."),
+	MEMBER_NO_LOGIN_SUCCESS(HttpStatus.OK, "회원번호 로그인이 성공적으로 완료되었습니다."),
+	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다.");
 
 	private final HttpStatus status;
 	private final String message;


### PR DESCRIPTION
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 나열해주세요. ex) - close #1 -->
- close #25

## 주요 변경 사항 (필수)
<!-- 변경사항을 나열해주세요. -->

- Redis 관련 파일 코드 리팩토링
    - `RedisConfig` 파일 수정 및 설정 추가
    - `RedisUtil` 파일 내 메서드 추가
    - `MemberRedis` 파일 코드 리팩토링

- Spring Security + JWT 로직 구현
    - JWT 의존성 버전 문제로 0.11.2 로 다운그레이드
    - `SecurityUtil` 추가
    - `SecurityConfig` 파일 수정
    - `CorsConfig` 설정 추가

- 로그인 로직 구현

- 로그아웃 로직 구현

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 작성해주세요. -->
### 1.  Redis 관련 파일 코드 리팩토링
    
이번 기능을 구현하면서 Redis 관련 파일들을 모두 리팩토링 하게 되었습니다.
    
 - RedisConfig 에 `customStringRedisTemplate`,`customObjectRedisTemplate` 두 가지 방식으로 레디스에 저장할 수 있도록 설정 변경
- RedisUtil 에 로직 구현을 위한 메서드 추가 및 수정
- MemberRedis 코드 리팩토링

<br>

### 2. Spring Security + JWT 로직 구현
- 기존에 사용하던 JWT 버전 사용 시 오류 해결이 되지 않아 0.11.2 로 다운그레이드 하게 되었습니다.
- SecurityConfig 파일 수정을 통해 메인페이지와 `signup`, `login`, `swagger` 경로를 제외한 모든 경로는 인증이 필요할 수 있도록 수정하였습니다.
        
   ** 로직을 구현하시면서 테스트 시, 인증 부분을 잠시 제거하고 싶으신 분들은 `authorizeHttpRequests` 부분에 테스트를 원하는 요청 경로만 잠시 permit 해주시고 나중에 제거 해주시면 될 것 같습니다.
        
- SecurityUtil 파일을 추가하여 **로그인 된 사용자 정보를 가져올 수 있도록** 하였습니다.
        
현재 로그인 된 사용자 정보를 가져오고 싶으신 분들은 `SecurityUtil.getCurrentMemberNo()` 를 통해 로그인 된 사용자의 회원번호 정보를 가져올 수 있습니다.
        
<br>

### 3. 로그인 로직 구현
    
현재 로그인 로직은 다음과 같습니다.
    
1. 요청으로 회원번호와 비밀번호를 전달
2. 미리 설정해 놓은 Security + JWT 를 통해 해당 사용자를 찾아 회원번호와 비밀번호가 일치하는지 확인
3. 일치한다면 JWT 토큰을 생성
4. Redis 에 `memberNo`, `refreshToken` 정보를 저장
5. TokenResponse 로 `accessToken`, `accessTokenExpiresIn`, `refreshToken` 정보를 전달

#### 로그인 성공
![스크린샷 2025-06-23 오후 3 35 43](https://github.com/user-attachments/assets/7893d511-5fe3-4938-b021-123c5821830a)

#### 로그인 성공 시 레디스 저장 정보
키: 회원번호
값: refreshToken 정보
![스크린샷 2025-06-23 오후 3 39 33](https://github.com/user-attachments/assets/48de983c-ad45-4746-89c0-017779eea947)



<br>

### 4. 로그아웃 로직 구현
    
로그아웃 시, 단순히 레디스 상에 저장한 `memberNo`, `refreshToken` 만 제거하면 `accessToken` 의 유효기간이 만료되지 않아 토큰이 살아있을 경우, **여전히 발급된 `accessToken` 으로 서버에 접근할 수 있는 상태가 됩니다.**
    
이를 방지하기 위해 `블랙리스트 방식`을 사용하여,
로그인 된 사용자의 `memberNo`, `refreshToken` 정보 제거 및 `accessToken` 을 레디스에 블랙리스트로 저장 하도록 로직을 구현하였습니다. 
    
해당 토큰 정보는 `accessToken` 이 만료되면 자동으로 레디스상에서 삭제 될 수 있도록 하였습니다.
   
<br>
 
현재 로그아웃 로직은 다음과 같습니다.
    
1. 요청으로 `accessToken` 과 `refreshToken` 정보를 전달
2. `accessToken` 이 유효한지 검증
3. 유효하다면 `accessToken` 에서 `memberNo` 를 가져와 레디스 상에 해당 `memberNo` 로 저장된 `refreshToken` 을 조회
4. 해당 정보가 존재할 경우 `refreshToken` 정보 삭제
5. 이미 발급된 `accessToken` 으로 더 이상 서버에 접근할 수 없도록 유효 시간을 설정하여 블랙리스트로 해당 토큰을 저장

만약 같은 `accessToken` 정보로 로그아웃을 시도하면 필터 중 
`jwtAuthenticationEntryPoint` 에서 걸리게 되며 403 에러를 반환합니다.

#### 로그아웃 성공
![스크린샷 2025-06-23 오후 4 03 11](https://github.com/user-attachments/assets/a82d2035-b295-474e-bc4e-9c7c36cbc325)

#### 로그아웃 성공 시 레디스에 저장되는 토큰 블랙리스트
키: accessToken
값: 로그아웃 정보, 유효시간
![스크린샷 2025-06-23 오후 3 46 59](https://github.com/user-attachments/assets/f54ec9ea-e9df-4864-82af-900170f903a0)



<br>

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 작성해주세요. -->
테스트들은 Hoppscotch 에 올려 놓았습니다.

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.