### PR TITLE
[FEATURE] 열차 운행 캘린더 조회

### DIFF
--- a/src/main/java/com/sudo/railo/global/domain/YesNo.java
+++ b/src/main/java/com/sudo/railo/global/domain/YesNo.java
@@ -1,0 +1,32 @@
+package com.sudo.railo.global.domain;
+
+import com.sudo.railo.global.exception.error.BusinessException;
+import com.sudo.railo.global.exception.error.GlobalError;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum YesNo {
+
+	Y("Y", true),
+	N("N", false);
+
+	private final String value;
+	private final boolean booleanValue;
+
+	public static YesNo from(boolean value) {
+		return value ? Y : N;
+	}
+
+	public static YesNo from(String value) {
+		if ("Y".equalsIgnoreCase(value)) {
+			return Y;
+		} else if ("N".equalsIgnoreCase(value)) {
+			return N;
+		} else {
+			throw new BusinessException(GlobalError.INVALID_YN_VALUE);
+		}
+	}
+}

--- a/src/main/java/com/sudo/railo/global/exception/error/GlobalError.java
+++ b/src/main/java/com/sudo/railo/global/exception/error/GlobalError.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum GlobalError implements ErrorCode{
+public enum GlobalError implements ErrorCode {
 
 	// 4xx 클라이언트 에러
 	INVALID_REQUEST_PARAM("요청 파라미터가 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "G_001"),
@@ -18,6 +18,7 @@ public enum GlobalError implements ErrorCode{
 	UNAUTHORIZED_ACCESS("인증이 필요합니다.", HttpStatus.UNAUTHORIZED, "G_006"),
 	FORBIDDEN_ACCESS("접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "G_007"),
 	METHOD_NOT_ALLOWED("허용되지 않은 HTTP 메소드입니다.", HttpStatus.METHOD_NOT_ALLOWED, "G_008"),
+	INVALID_YN_VALUE("Y 또는 N 값만 허용됩니다.", HttpStatus.BAD_REQUEST, "G_009"),
 
 	// 5xx 서버 에러
 	INTERNAL_SERVER_ERROR("내부 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "G_500"),

--- a/src/main/java/com/sudo/railo/train/application/TrainScheduleService.java
+++ b/src/main/java/com/sudo/railo/train/application/TrainScheduleService.java
@@ -1,6 +1,5 @@
 package com.sudo.railo.train.application;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
@@ -9,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sudo.railo.train.application.dto.request.OperationCalendarItem;
-import com.sudo.railo.train.infrastructure.TrainScheduleRepository;
+import com.sudo.railo.train.infrastructure.TrainScheduleRepositoryCustom;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,14 +19,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TrainScheduleService {
 
-	private final TrainScheduleRepository trainScheduleRepository;
+	private final TrainScheduleRepositoryCustom trainScheduleRepositoryCustom;
 
 	public List<OperationCalendarItem> getOperationCalendar() {
 		LocalDate startDate = LocalDate.now();
 		LocalDate endDate = startDate.plusMonths(1);
 
 		// 운행 날짜 조회 (Set으로 반환)
-		Set<LocalDate> datesWithSchedule = trainScheduleRepository.findDatesWithActiveSchedules(startDate, endDate);
+		Set<LocalDate> datesWithSchedule = trainScheduleRepositoryCustom.findDatesWithActiveSchedules(startDate,
+			endDate);
 
 		List<OperationCalendarItem> calendar = startDate.datesUntil(endDate.plusDays(1))
 			.map(date -> {
@@ -48,7 +48,25 @@ public class TrainScheduleService {
 	 * TODO : 공휴일 API 연동 후 판단 처리 로직 추가 필요
 	 */
 	private boolean isHoliday(LocalDate date) {
-		DayOfWeek dayOfWeek = date.getDayOfWeek();
-		return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+		// 2025년 공휴일 임시 하드코딩
+		Set<LocalDate> holidays2025 = Set.of(
+			LocalDate.of(2025, 1, 1),   // 신정
+			LocalDate.of(2025, 1, 28),  // 설날 연휴
+			LocalDate.of(2025, 1, 29),  // 설날
+			LocalDate.of(2025, 1, 30),  // 설날 연휴
+			LocalDate.of(2025, 3, 1),   // 삼일절
+			LocalDate.of(2025, 5, 5),   // 어린이날
+			LocalDate.of(2025, 6, 6),   // 현충일
+			LocalDate.of(2025, 8, 15),  // 광복절
+			LocalDate.of(2025, 10, 3),  // 개천절
+			LocalDate.of(2025, 10, 5),  // 추석 연휴
+			LocalDate.of(2025, 10, 6),  // 추석 연휴
+			LocalDate.of(2025, 10, 7),  // 추석 연휴
+			LocalDate.of(2025, 10, 8),  // 추석
+			LocalDate.of(2025, 10, 9),  // 한글날
+			LocalDate.of(2025, 12, 25)  // 크리스마스
+		);
+
+		return holidays2025.contains(date);
 	}
 }

--- a/src/main/java/com/sudo/railo/train/application/TrainScheduleService.java
+++ b/src/main/java/com/sudo/railo/train/application/TrainScheduleService.java
@@ -1,0 +1,54 @@
+package com.sudo.railo.train.application;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sudo.railo.train.application.dto.request.OperationCalendarItem;
+import com.sudo.railo.train.infrastructure.TrainScheduleRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class TrainScheduleService {
+
+	private final TrainScheduleRepository trainScheduleRepository;
+
+	public List<OperationCalendarItem> getOperationCalendar() {
+		LocalDate startDate = LocalDate.now();
+		LocalDate endDate = startDate.plusMonths(1);
+
+		// 운행 날짜 조회 (Set으로 반환)
+		Set<LocalDate> datesWithSchedule = trainScheduleRepository.findDatesWithActiveSchedules(startDate, endDate);
+
+		List<OperationCalendarItem> calendar = startDate.datesUntil(endDate.plusDays(1))
+			.map(date -> {
+				boolean isHoliday = isHoliday(date);
+				boolean hasSchedule = datesWithSchedule.contains(date);
+				return OperationCalendarItem.create(date, isHoliday, hasSchedule);
+			})
+			.toList();
+
+		log.info("운행 캘린더 조회 완료: {} ~ {} ({} 일), 운행일수: {}",
+			startDate, endDate, calendar.size(), datesWithSchedule.size());
+
+		return calendar;
+	}
+
+	/**
+	 * 휴일 여부 판단
+	 * TODO : 공휴일 API 연동 후 판단 처리 로직 추가 필요
+	 */
+	private boolean isHoliday(LocalDate date) {
+		DayOfWeek dayOfWeek = date.getDayOfWeek();
+		return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+	}
+}

--- a/src/main/java/com/sudo/railo/train/application/dto/request/OperationCalendarItem.java
+++ b/src/main/java/com/sudo/railo/train/application/dto/request/OperationCalendarItem.java
@@ -1,0 +1,54 @@
+package com.sudo.railo.train.application.dto.request;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import com.sudo.railo.global.domain.YesNo;
+import com.sudo.railo.train.domain.type.BusinessDayType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OperationCalendarItem(
+
+	@Schema(description = "운행 날짜", example = "2025-06-20")
+	LocalDate operationDate,
+
+	@Schema(description = "요일 (MONDAY, TUESDAY, ...", example = "FRIDAY")
+	DayOfWeek dayOfWeek,
+
+	@Schema(description = "영업일 구분 (WEEKDAY, WEEKEND, HOLIDAY)", example = "WEEKDAY")
+	BusinessDayType businessDayType,
+
+	@Schema(description = "휴일 여부 (Y/N)", example = "N")
+	String isHoliday,
+
+	@Schema(description = "예약 가능 여부 (Y/N), 해당 날짜에 KTX 운행 스케줄 존재 여부", example = "Y")
+	String isBookingAvailable
+) {
+
+	public static OperationCalendarItem create(LocalDate operationDate, boolean isHoliday, boolean hasSchedule) {
+		return new OperationCalendarItem(
+			operationDate,
+			operationDate.getDayOfWeek(),
+			determineBusinessDayType(operationDate, isHoliday),
+			YesNo.from(isHoliday).getValue(),
+			YesNo.from(hasSchedule).getValue()
+		);
+	}
+
+	/**
+	 * 영업일 구분
+	 */
+	private static BusinessDayType determineBusinessDayType(LocalDate date, boolean isHoliday) {
+		if (isHoliday) {
+			return BusinessDayType.HOLIDAY;
+		}
+
+		DayOfWeek dayOfWeek = date.getDayOfWeek();
+		if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) {
+			return BusinessDayType.WEEKEND;
+		}
+
+		return BusinessDayType.WEEKDAY;
+	}
+}

--- a/src/main/java/com/sudo/railo/train/application/dto/request/OperationCalendarItem.java
+++ b/src/main/java/com/sudo/railo/train/application/dto/request/OperationCalendarItem.java
@@ -30,25 +30,9 @@ public record OperationCalendarItem(
 		return new OperationCalendarItem(
 			operationDate,
 			operationDate.getDayOfWeek(),
-			determineBusinessDayType(operationDate, isHoliday),
+			BusinessDayType.fromDate(operationDate, isHoliday),
 			YesNo.from(isHoliday).getValue(),
 			YesNo.from(hasSchedule).getValue()
 		);
-	}
-
-	/**
-	 * 영업일 구분
-	 */
-	private static BusinessDayType determineBusinessDayType(LocalDate date, boolean isHoliday) {
-		if (isHoliday) {
-			return BusinessDayType.HOLIDAY;
-		}
-
-		DayOfWeek dayOfWeek = date.getDayOfWeek();
-		if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) {
-			return BusinessDayType.WEEKEND;
-		}
-
-		return BusinessDayType.WEEKDAY;
 	}
 }

--- a/src/main/java/com/sudo/railo/train/application/dto/request/ScheduleSearchRequest.java
+++ b/src/main/java/com/sudo/railo/train/application/dto/request/ScheduleSearchRequest.java
@@ -1,0 +1,37 @@
+package com.sudo.railo.train.application.dto.request;
+
+import java.time.LocalDate;
+
+import com.sudo.railo.train.domain.type.CarType;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ScheduleSearchRequest(
+
+	@NotNull(message = "운행 날짜는 필수입니다")
+	LocalDate operationDate,
+
+	@NotNull(message = "출발역은 필수입니다")
+	Long departureStationId,
+
+	@NotNull(message = "도착역은 필수입니다")
+	Long arrivalStationId,
+
+	@Min(value = 1, message = "승객 수는 1명 이상이어야 합니다")
+	@Max(value = 9, message = "승객 수는 9명 이하여야 합니다")
+	Integer passengerCount,
+
+	CarType preferredCarType     // 선호 좌석 타입 (필터링용, nullable)
+) {
+
+	/* 생성 메서드 */
+	// 컴팩트 생성자
+	public ScheduleSearchRequest(LocalDate operationDate,
+		Long departureStationId,
+		Long arrivalStationId,
+		Integer passengerCount) {
+		this(operationDate, departureStationId, arrivalStationId, passengerCount, null);
+	}
+}

--- a/src/main/java/com/sudo/railo/train/application/dto/response/TrainScheduleSuccess.java
+++ b/src/main/java/com/sudo/railo/train/application/dto/response/TrainScheduleSuccess.java
@@ -1,0 +1,19 @@
+package com.sudo.railo.train.application.dto.response;
+
+import org.springframework.http.HttpStatus;
+
+import com.sudo.railo.global.success.SuccessCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TrainScheduleSuccess implements SuccessCode {
+
+	OPERATION_CALENDAR_SUCCESS(HttpStatus.OK, "운행 캘린더 조회가 완료되었습니다."),
+	SCHEDULE_SEARCH_SUCCESS(HttpStatus.OK, "열차 스케줄 검색이 완료되었습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/sudo/railo/train/domain/TrainSchedule.java
+++ b/src/main/java/com/sudo/railo/train/domain/TrainSchedule.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.sudo.railo.train.domain.status.OperationStatus;
 import com.sudo.railo.train.domain.type.CarType;
 import com.sudo.railo.train.domain.type.SeatAvailabilityStatus;
 
@@ -40,13 +41,13 @@ import lombok.NoArgsConstructor;
 		@Index(name = "idx_schedule_booking",
 			columnList = "operation_date, departure_station_id, arrival_station_id, operation_status, departure_time"),
 
-		// 2. 열차별 날짜 검색 (관리자용, 특정 열차 스케줄 조회)
+		// 2. 캘린더 전용 인덱스 (날짜별 운행 여부 조회)
+		@Index(name = "idx_schedule_calendar",
+			columnList = "operation_date, operation_status"),
+
+		// 3. 열차별 날짜 검색 (관리자용, 특정 열차 스케줄 조회)
 		@Index(name = "idx_schedule_train_date",
 			columnList = "train_id, operation_date"),
-
-		// 3. 출발 시간 정렬 (같은 구간 내 시간순 조회)
-		@Index(name = "idx_schedule_departure_time",
-			columnList = "departure_time")
 	}
 )
 public class TrainSchedule {

--- a/src/main/java/com/sudo/railo/train/domain/status/OperationStatus.java
+++ b/src/main/java/com/sudo/railo/train/domain/status/OperationStatus.java
@@ -1,4 +1,4 @@
-package com.sudo.railo.train.domain;
+package com.sudo.railo.train.domain.status;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sudo/railo/train/domain/type/BusinessDayType.java
+++ b/src/main/java/com/sudo/railo/train/domain/type/BusinessDayType.java
@@ -26,8 +26,8 @@ public enum BusinessDayType {
 	public static BusinessDayType fromCode(String code) {
 		return switch (code) {
 			case "1" -> WEEKDAY;
-			case "2" -> HOLIDAY;
-			case "3" -> WEEKEND;
+			case "2" -> WEEKEND;
+			case "3" -> HOLIDAY;
 			default -> WEEKDAY;  // null이나 알 수 없는 코드는 평일로 처리
 		};
 	}

--- a/src/main/java/com/sudo/railo/train/domain/type/BusinessDayType.java
+++ b/src/main/java/com/sudo/railo/train/domain/type/BusinessDayType.java
@@ -1,0 +1,50 @@
+package com.sudo.railo.train.domain.type;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 영업일 구분
+ */
+@Getter
+@RequiredArgsConstructor
+public enum BusinessDayType {
+
+	WEEKDAY("1", "평일"),
+	WEEKEND("2", "주말"),
+	HOLIDAY("3", "공휴일");
+
+	private final String code;
+	private final String displayName;
+
+	/**
+	 * 코드로 BusinessType 반환
+	 */
+	public static BusinessDayType fromCode(String code) {
+		return switch (code) {
+			case "1" -> WEEKDAY;
+			case "2" -> HOLIDAY;
+			case "3" -> WEEKEND;
+			default -> WEEKDAY;  // null이나 알 수 없는 코드는 평일로 처리
+		};
+	}
+
+	/**
+	 * 날짜로 BusinessDayType 반환
+	 */
+	public static BusinessDayType fromDate(LocalDate date, boolean isHoliday) {
+		if (isHoliday) {
+			return HOLIDAY;
+		}
+
+		DayOfWeek dayOfWeek = date.getDayOfWeek();
+		if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) {
+			return WEEKEND;
+		}
+
+		return WEEKDAY;
+	}
+}

--- a/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepository.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepository.java
@@ -1,28 +1,9 @@
 package com.sudo.railo.train.infrastructure;
 
-import java.time.LocalDate;
-import java.util.Set;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.sudo.railo.train.domain.TrainSchedule;
 
 public interface TrainScheduleRepository extends JpaRepository<TrainSchedule, Long> {
 
-	/**
-	 * 날짜 범위에서 활성 스케줄이 있는 날짜들 조회 (운행 스케줄 캘린더 조회)
-	 * TODO : 성능 모니터링 필요 : operation_calender 테이블, 배치, 캐시로 성능 개선 예정
-	 */
-	@Query("""
-		SELECT DISTINCT ts.operationDate
-		        FROM TrainSchedule ts
-		        WHERE ts.operationDate BETWEEN :startDate AND :endDate
-		        AND ts.operationStatus IN ('ACTIVE', 'DELAYED')
-		        ORDER BY ts.operationDate
-		""")
-	Set<LocalDate> findDatesWithActiveSchedules(
-		@Param("startDate") LocalDate startDate,
-		@Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepository.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepository.java
@@ -1,0 +1,28 @@
+package com.sudo.railo.train.infrastructure;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.sudo.railo.train.domain.TrainSchedule;
+
+public interface TrainScheduleRepository extends JpaRepository<TrainSchedule, Long> {
+
+	/**
+	 * 날짜 범위에서 활성 스케줄이 있는 날짜들 조회 (운행 스케줄 캘린더 조회)
+	 * TODO : 성능 모니터링 필요 : operation_calender 테이블, 배치, 캐시로 성능 개선 예정
+	 */
+	@Query("""
+		SELECT DISTINCT ts.operationDate
+		        FROM TrainSchedule ts
+		        WHERE ts.operationDate BETWEEN :startDate AND :endDate
+		        AND ts.operationStatus IN ('ACTIVE', 'DELAYED')
+		        ORDER BY ts.operationDate
+		""")
+	Set<LocalDate> findDatesWithActiveSchedules(
+		@Param("startDate") LocalDate startDate,
+		@Param("endDate") LocalDate endDate);
+}

--- a/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepositoryCustom.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.sudo.railo.train.infrastructure;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+public interface TrainScheduleRepositoryCustom {
+
+	/**
+	 * 날짜 범위에서 활성 스케줄이 있는 날짜들 조회 (운행 스케줄 캘린더 조회)
+	 * TODO : 성능 모니터링 필요 : operation_calender 테이블, 배치, 캐시로 성능 개선 예정
+	 */
+	Set<LocalDate> findDatesWithActiveSchedules(LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepositoryCustomImpl.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepositoryCustomImpl.java
@@ -1,0 +1,47 @@
+package com.sudo.railo.train.infrastructure;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sudo.railo.train.domain.QTrainSchedule;
+import com.sudo.railo.train.domain.status.OperationStatus;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 열차 스케줄 커스텀 Repository 구현체
+ * QueryDSL을 활용한 복잡한 쿼리 및 성능이 중요한 복잡한 조회 로직
+ */
+@Repository
+@RequiredArgsConstructor
+public class TrainScheduleRepositoryCustomImpl implements TrainScheduleRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	/**
+	 * 날짜 범위에서 활성 스케줄이 있는 날짜들 조회 (운행 스케줄 캘린더 조회)
+	 * TODO : 성능 모니터링 필요 : operation_calender 테이블, 배치, 캐시로 성능 개선 예정
+	 */
+	@Override
+	public Set<LocalDate> findDatesWithActiveSchedules(LocalDate startDate, LocalDate endDate) {
+		QTrainSchedule trainSchedule = QTrainSchedule.trainSchedule;
+
+		List<LocalDate> dates = queryFactory
+			.select(trainSchedule.operationDate)
+			.distinct()
+			.from(trainSchedule)
+			.where(
+				trainSchedule.operationDate.between(startDate, endDate)
+					.and(trainSchedule.operationStatus.in(OperationStatus.ACTIVE, OperationStatus.DELAYED))
+			)
+			.orderBy(trainSchedule.operationDate.asc())
+			.fetch();
+
+		return new LinkedHashSet<>(dates);
+	}
+}

--- a/src/main/java/com/sudo/railo/train/presentation/TrainScheduleController.java
+++ b/src/main/java/com/sudo/railo/train/presentation/TrainScheduleController.java
@@ -30,7 +30,7 @@ public class TrainScheduleController {
 	 */
 	@GetMapping("/calendar")
 	@Operation(summary = "운행 캘린더 조회", description = "금일로부터 한 달간의 운행 캘린더를 조회합니다.")
-	public SuccessResponse<List<OperationCalendarItem>> getOperationCalender() {
+	public SuccessResponse<List<OperationCalendarItem>> getOperationCalendar() {
 		log.info("운행 캘린더 조회");
 		List<OperationCalendarItem> calendar = trainScheduleService.getOperationCalendar();
 		log.info("운행 캘린더 조회: {} 건", calendar.size());

--- a/src/main/java/com/sudo/railo/train/presentation/TrainScheduleController.java
+++ b/src/main/java/com/sudo/railo/train/presentation/TrainScheduleController.java
@@ -1,0 +1,40 @@
+package com.sudo.railo.train.presentation;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sudo.railo.global.success.SuccessResponse;
+import com.sudo.railo.train.application.TrainScheduleService;
+import com.sudo.railo.train.application.dto.request.OperationCalendarItem;
+import com.sudo.railo.train.application.dto.response.TrainScheduleSuccess;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/api/v1/train-schedule")
+@RequiredArgsConstructor
+@Tag(name = "열차 스케줄", description = "열차 스케줄 조회 API")
+@Slf4j
+public class TrainScheduleController {
+
+	private final TrainScheduleService trainScheduleService;
+
+	/**
+	 * 운행 캘린더 조회
+	 */
+	@GetMapping("/calendar")
+	@Operation(summary = "운행 캘린더 조회", description = "금일로부터 한 달간의 운행 캘린더를 조회합니다.")
+	public SuccessResponse<List<OperationCalendarItem>> getOperationCalender() {
+		log.info("운행 캘린더 조회");
+		List<OperationCalendarItem> calendar = trainScheduleService.getOperationCalendar();
+		log.info("운행 캘린더 조회: {} 건", calendar.size());
+
+		return SuccessResponse.of(TrainScheduleSuccess.OPERATION_CALENDAR_SUCCESS, calendar);
+	}
+}


### PR DESCRIPTION
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 나열해주세요. ex) - close #37  -->
- close #37 

## 주요 변경 사항 (필수)
<!-- 변경사항을 나열해주세요. -->
- 운행 캘린더 조회 API 구현 (`/api/v1/train-schedule/calendar`)
- 금일부터 한 달간의 열차 운행 여부를 조회
  - 운행일/비운행일, 평일/주말/공휴일 여부 포함
  - TrainScheduleRepository.findDatesWithActiveSchedules() 쿼리 작성
  - 활성(ACTIVE, DELAYED) 상태의 스케줄만 조회
  - 운행 스케줄 존재 여부와 휴일 판별을 위한 OperationCalendarItem DTO로 응답 정의
  - 영업일 구분 Enum (`BusinessDayType`) 및 Y/N 변환 Enum (`YesNo`) 추가


## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 작성해주세요. -->
아래 이미지의 캘린더 선택을 위한 조회 API입니다.
![image](https://github.com/user-attachments/assets/b336b725-8e1a-434e-87aa-e4d0d402a133)

API 조회 결과는 아래와 같습니다.
![image](https://github.com/user-attachments/assets/ef3fbf13-2366-4d2c-820c-d606af8bc7ed)

- 현재 `isHoliday()`는 주말만 판단하고 있으며, 추후 2차로 넘어가서 시간이 남는다면 공휴일 API 연동 작업을 할 예정입니다. (TODO)
- 캘린더 response는 평일/주말/공휴일 구분과 예약 가능 여부를 포함합니다.
- JPA 쿼리 튜닝 및 캐싱 전략은 2차로 넘길 예정입니다. 

> 아직 현재 시간 이후, 선택한 시간 이후의 필터링은 적용하지 못했습니다. 열차 조회 (#5) 작업을 마친 후 다시 작업하여 올리겠습니다.

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 작성해주세요. -->

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.