### PR TITLE
[FEATURE] 비회원 정보 저장 로직 구현

### DIFF
--- a/src/main/java/com/sudo/railo/global/security/SecurityConfig.java
+++ b/src/main/java/com/sudo/railo/global/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
 			// HTTP 요청에 대한 접근 권한 설정
 			.authorizeHttpRequests(auth -> {
 				auth.requestMatchers("/", "/auth/signup", "/auth/login").permitAll()
+					.requestMatchers("/api/v1/guest/register").permitAll()
 					.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
 					.anyRequest().authenticated();
 			})

--- a/src/main/java/com/sudo/railo/member/application/MemberService.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberService.java
@@ -1,0 +1,9 @@
+package com.sudo.railo.member.application;
+
+import com.sudo.railo.member.application.dto.request.GuestRegisterRequest;
+import com.sudo.railo.member.application.dto.response.GuestRegisterResponse;
+
+public interface MemberService {
+
+	GuestRegisterResponse guestRegister(GuestRegisterRequest request);
+}

--- a/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
@@ -1,0 +1,44 @@
+package com.sudo.railo.member.application;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sudo.railo.global.exception.error.BusinessException;
+import com.sudo.railo.member.application.dto.request.GuestRegisterRequest;
+import com.sudo.railo.member.application.dto.response.GuestRegisterResponse;
+import com.sudo.railo.member.domain.Member;
+import com.sudo.railo.member.domain.Role;
+import com.sudo.railo.member.exception.MemberError;
+import com.sudo.railo.member.infra.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	@Transactional
+	public GuestRegisterResponse guestRegister(GuestRegisterRequest request) {
+
+		// 중복 체크
+		if (memberRepository.existsByNameAndPhoneNumber(request.name(), request.phoneNumber())) {
+			Member member = memberRepository.findByNameAndPhoneNumber(request.name(), request.phoneNumber());
+
+			if (passwordEncoder.matches(request.password(), member.getPassword())) {
+				throw new BusinessException(MemberError.DUPLICATE_GUEST_INFO);
+			}
+		}
+
+		String encodedPassword = passwordEncoder.encode(request.password());
+
+		Member member = Member.create(request.name(), request.phoneNumber(), encodedPassword, Role.GUEST, null);
+		memberRepository.save(member);
+
+		return new GuestRegisterResponse(request.name(), Role.GUEST);
+	}
+}

--- a/src/main/java/com/sudo/railo/member/application/dto/request/GuestRegisterRequest.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/request/GuestRegisterRequest.java
@@ -1,0 +1,19 @@
+package com.sudo.railo.member.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record GuestRegisterRequest(
+
+	@NotBlank(message = "이름은 필수입니다.")
+	String name,
+
+	@NotBlank(message = "전화번호는 필수입니다.")
+	@Pattern(regexp = "^[0-9]{11}$", message = "전화번호는 -를 제외한 11자리 숫자만 가능합니다.")
+	String phoneNumber,
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	@Pattern(regexp = "^[0-9]{5}$", message = "비밀번호는 5자리 숫자만 가능합니다.")
+	String password
+) {
+}

--- a/src/main/java/com/sudo/railo/member/application/dto/response/GuestRegisterResponse.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/response/GuestRegisterResponse.java
@@ -1,0 +1,9 @@
+package com.sudo.railo.member.application.dto.response;
+
+import com.sudo.railo.member.domain.Role;
+
+public record GuestRegisterResponse(
+	String name,
+	Role role
+) {
+}

--- a/src/main/java/com/sudo/railo/member/domain/Member.java
+++ b/src/main/java/com/sudo/railo/member/domain/Member.java
@@ -52,4 +52,9 @@ public class Member extends BaseEntity {
 		MemberDetail memberDetail) {
 		return new Member(name, phoneNumber, password, role, memberDetail);
 	}
+
+	// 비회원 등록 정적 팩토리 메서드
+	public static Member guestCreate(String name, String phoneNumber, String password) {
+		return new Member(name, phoneNumber, password, Role.GUEST, null);
+	}
 }

--- a/src/main/java/com/sudo/railo/member/exception/MemberError.java
+++ b/src/main/java/com/sudo/railo/member/exception/MemberError.java
@@ -13,7 +13,8 @@ public enum MemberError implements ErrorCode {
 
 	USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "M_001"),
 	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT, "M_002"),
-	INVALID_PASSWORD("비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED, "M_003");
+	INVALID_PASSWORD("비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED, "M_003"),
+	DUPLICATE_GUEST_INFO("이미 동일한 비회원 정보가 존재합니다.", HttpStatus.CONFLICT, "M_004");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/railo/member/infra/MemberRepository.java
+++ b/src/main/java/com/sudo/railo/member/infra/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.sudo.railo.member.infra;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sudo.railo.member.domain.Member;
@@ -7,7 +9,5 @@ import com.sudo.railo.member.domain.Member;
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 	boolean existsByMemberDetailEmail(String email);
 
-	boolean existsByNameAndPhoneNumber(String name, String phoneNumber);
-
-	Member findByNameAndPhoneNumber(String name, String phoneNumber);
+	List<Member> findByNameAndPhoneNumber(String name, String phoneNumber);
 }

--- a/src/main/java/com/sudo/railo/member/infra/MemberRepository.java
+++ b/src/main/java/com/sudo/railo/member/infra/MemberRepository.java
@@ -6,4 +6,8 @@ import com.sudo.railo.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 	boolean existsByMemberDetailEmail(String email);
+
+	boolean existsByNameAndPhoneNumber(String name, String phoneNumber);
+
+	Member findByNameAndPhoneNumber(String name, String phoneNumber);
 }

--- a/src/main/java/com/sudo/railo/member/presentation/MemberController.java
+++ b/src/main/java/com/sudo/railo/member/presentation/MemberController.java
@@ -1,0 +1,31 @@
+package com.sudo.railo.member.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sudo.railo.global.success.SuccessResponse;
+import com.sudo.railo.member.application.MemberService;
+import com.sudo.railo.member.application.dto.request.GuestRegisterRequest;
+import com.sudo.railo.member.application.dto.response.GuestRegisterResponse;
+import com.sudo.railo.member.success.MemberSuccess;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@PostMapping("/guest/register")
+	public SuccessResponse<GuestRegisterResponse> guestRegister(@RequestBody @Valid GuestRegisterRequest request) {
+
+		GuestRegisterResponse response = memberService.guestRegister(request);
+
+		return SuccessResponse.of(MemberSuccess.GUEST_REGISTER_SUCCESS, response);
+	}
+}

--- a/src/main/java/com/sudo/railo/member/success/MemberSuccess.java
+++ b/src/main/java/com/sudo/railo/member/success/MemberSuccess.java
@@ -1,0 +1,18 @@
+package com.sudo.railo.member.success;
+
+import org.springframework.http.HttpStatus;
+
+import com.sudo.railo.global.success.SuccessCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberSuccess implements SuccessCode {
+
+	GUEST_REGISTER_SUCCESS(HttpStatus.CREATED, "비회원 정보 등록이 성공적으로 완료되었습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+}


### PR DESCRIPTION
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 나열해주세요. ex) - close #1 -->
- close #39 

## 주요 변경 사항 (필수)
<!-- 변경사항을 나열해주세요. -->
- SpringConfig 비회원 등록 요청 경로 추가
- 비회원 등록 로직 구현

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 작성해주세요. -->
비회원 정보 등록 시 요청으로 `name`, `phoneNumber`, `password` 3가지 정보를 받아옵니다.

서비스 로직에서 먼저 이 3가지 정보가 DB에 저장되어 있는지 확인하여 중복 검증을 수행하게 됩니다.
3가지 정보가 1가지라도 일치하지 않는다면 다른 비회원 정보로 보고 요청 정보가 저장되며,
3가지 정보가 모두 같다면 중복된 비회원 정보 예외를 던지게 됩니다.

### 비회원 정보 등록 성공
![스크린샷 2025-06-24 오후 2 51 30](https://github.com/user-attachments/assets/c9dd56e2-75f1-44a5-9e9f-f30c71848f77)


### 비회원 정보 등록 실패
![스크린샷 2025-06-24 오후 2 51 38](https://github.com/user-attachments/assets/845710f8-8c6b-47df-bf60-b86950e35c9b)


## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 작성해주세요. -->
테스트는 Hoppscotch 에 올려두었습니다 !

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.