### PR TITLE
[FEATURE] 로그아웃 로직 수정

### DIFF
--- a/src/main/java/com/sudo/railo/global/security/SecurityConfig.java
+++ b/src/main/java/com/sudo/railo/global/security/SecurityConfig.java
@@ -18,6 +18,7 @@ import com.sudo.railo.global.redis.RedisUtil;
 import com.sudo.railo.global.security.jwt.JwtAccessDeniedHandler;
 import com.sudo.railo.global.security.jwt.JwtAuthenticationEntryPoint;
 import com.sudo.railo.global.security.jwt.JwtFilter;
+import com.sudo.railo.global.security.jwt.TokenExtractor;
 import com.sudo.railo.global.security.jwt.TokenProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class SecurityConfig {
 
 	private final RedisUtil redisUtil;
 	private final TokenProvider tokenProvider;
+	private final TokenExtractor tokenExtractor;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
@@ -61,7 +63,8 @@ public class SecurityConfig {
 					.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
 					.anyRequest().authenticated();
 			})
-			.addFilterBefore(new JwtFilter(tokenProvider, redisUtil), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new JwtFilter(tokenExtractor, tokenProvider, redisUtil),
+				UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}
 }

--- a/src/main/java/com/sudo/railo/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/JwtFilter.java
@@ -22,8 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-	public static final String AUTHORIZATION_HEADER = "Authorization";
-	public static final String BEARER_PREFIX = "Bearer";
+	private final TokenExtractor tokenExtractor;
 	private final TokenProvider tokenProvider;
 	private final RedisUtil redisUtil;
 
@@ -34,8 +33,8 @@ public class JwtFilter extends OncePerRequestFilter {
 		HttpServletResponse response,
 		FilterChain filterChain
 	) throws ServletException, IOException {
-
-		String jwt = resolveToken(request);
+		
+		String jwt = tokenExtractor.resolveToken(request);
 
 		if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
 
@@ -54,13 +53,4 @@ public class JwtFilter extends OncePerRequestFilter {
 		filterChain.doFilter(request, response);
 	}
 
-	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-			return bearerToken.substring(7);
-		}
-
-		return null;
-	}
 }

--- a/src/main/java/com/sudo/railo/global/security/jwt/TokenExtractor.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/TokenExtractor.java
@@ -1,0 +1,23 @@
+package com.sudo.railo.global.security.jwt;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class TokenExtractor {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String BEARER_PREFIX = "Bearer";
+
+	public String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(7);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/sudo/railo/member/application/MemberAuthService.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberAuthService.java
@@ -2,9 +2,10 @@ package com.sudo.railo.member.application;
 
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
-import com.sudo.railo.member.application.dto.request.TokenRequest;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface MemberAuthService {
 
@@ -12,6 +13,6 @@ public interface MemberAuthService {
 
 	TokenResponse memberNoLogin(MemberNoLoginRequest request);
 
-	void logout(TokenRequest request);
+	void logout(HttpServletRequest request);
 
 }

--- a/src/main/java/com/sudo/railo/member/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/member/presentation/AuthController.java
@@ -9,11 +9,11 @@ import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.member.application.MemberAuthService;
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
-import com.sudo.railo.member.application.dto.request.TokenRequest;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
 import com.sudo.railo.member.success.AuthSuccess;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -41,7 +41,7 @@ public class AuthController {
 	}
 
 	@PostMapping("/logout")
-	public SuccessResponse<?> logout(@RequestBody @Valid TokenRequest request) {
+	public SuccessResponse<?> logout(HttpServletRequest request) {
 
 		memberAuthService.logout(request);
 


### PR DESCRIPTION
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 나열해주세요. ex) - close #1 -->
- close #48

## 주요 변경 사항 (필수)
<!-- 변경사항을 나열해주세요. -->
- 토큰 추출 클래스 추가
- 로그아웃 서비스 로직 수정

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 작성해주세요. -->
### 토큰 추출 클래스 추가
기존 코드에서는 `jwtFilter` 라는 커스텀 필터 내부에서 사용할 수 있는 resolveToken() 메서드로 토큰 정보를 추출하였습니다.
`TokenExtractor` 를 추가하여 요청 헤더에서 토큰 정보를 추출 할 수 있는 클래스를 따로 추가 하여 기능을 분리 하였습니다.

### 로그아웃 서비스 로직 수정
기존 로직은 클라이언트 측에서 직접 accessToken 과 refreshToken 을 받아와 처리하는 로직으로 구현 되었었습니다.
이번 수정으로 클라이언트에서 직접 토큰을 받아올 필요 없이,
요청으로 들어온 헤더에서 토큰 정보를 추출하여 내부적으로 로그아웃을 수행할 수 있도록 로직을 수정하였습니다.


## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 작성해주세요. -->
코드를 수정하며 Hoppscotch 에 올려둔 테스트 또한 다시 수행 하여 문제 없음을 확인하였습니다 :)

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.