### PR TITLE
[FEATURE] AccessToken 재발급 로직 구현

### DIFF
--- a/src/main/java/com/sudo/railo/global/security/TokenError.java
+++ b/src/main/java/com/sudo/railo/global/security/TokenError.java
@@ -16,7 +16,8 @@ public enum TokenError implements ErrorCode {
 	LOGOUT_ERROR("로그아웃: 토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_003"),
 	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "T_004"),
 	INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_005"),
-	AUTHORITY_NOT_FOUND("권한 정보가 없는 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_006");
+	AUTHORITY_NOT_FOUND("권한 정보가 없는 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_006"),
+	NOT_EQUALS_REFRESH_TOKEN("리프레시 토큰이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_007");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/railo/global/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/JwtAccessDeniedHandler.java
@@ -19,6 +19,6 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 		HttpServletResponse response,
 		AccessDeniedException accessDeniedException
 	) throws IOException {
-		response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+		response.sendError(HttpServletResponse.SC_FORBIDDEN);
 	}
 }

--- a/src/main/java/com/sudo/railo/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -19,6 +19,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 		HttpServletResponse response,
 		AuthenticationException authException
 	) throws IOException {
-		response.sendError(HttpServletResponse.SC_FORBIDDEN);
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 	}
 }

--- a/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import com.sudo.railo.global.exception.error.BusinessException;
-import com.sudo.railo.global.redis.RedisUtil;
 import com.sudo.railo.global.security.TokenError;
 import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
@@ -41,14 +40,12 @@ public class TokenProvider {
 	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
 	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
 	private final Key key;
-	private final RedisUtil redisUtil;
 
 	public TokenProvider(
-		@Value("${jwt.secret}") String secretKey, RedisUtil redisUtil
+		@Value("${jwt.secret}") String secretKey
 	) {
 		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
 		this.key = Keys.hmacShaKeyFor(keyBytes);
-		this.redisUtil = redisUtil;
 	}
 
 	// 토큰 생성 메서드

--- a/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
@@ -16,9 +16,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import com.sudo.railo.global.exception.error.BusinessException;
-import com.sudo.railo.global.redis.MemberRedis;
 import com.sudo.railo.global.redis.RedisUtil;
 import com.sudo.railo.global.security.TokenError;
+import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
 
 import io.jsonwebtoken.Claims;
@@ -98,7 +98,7 @@ public class TokenProvider {
 			.compact();
 	}
 
-	public TokenResponse reissueAccessToken(String refreshToken) {
+	public ReissueTokenResponse reissueAccessToken(String refreshToken) {
 
 		// 리프레시 토큰에서 사용자 정보 추출 -> 클레임 확인
 		Claims claims = parseClaims(refreshToken);
@@ -113,19 +113,14 @@ public class TokenProvider {
 		String authorities = claims.get(AUTHORITIES_KEY).toString();
 
 		String newAccessToken = generateAccessToken(memberNo, authorities);
-		String newRefreshToken = generateRefreshToken(memberNo, authorities);
-
-		MemberRedis memberRedis = new MemberRedis(memberNo, newRefreshToken);
-		redisUtil.saveMemberToken(memberRedis);
 
 		long now = System.currentTimeMillis();
 		Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
 
-		return new TokenResponse(
+		return new ReissueTokenResponse(
 			BEARER_TYPE,
 			newAccessToken,
-			accessTokenExpiresIn.getTime(),
-			newRefreshToken
+			accessTokenExpiresIn.getTime()
 		);
 	}
 

--- a/src/main/java/com/sudo/railo/member/application/MemberAuthService.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberAuthService.java
@@ -2,10 +2,9 @@ package com.sudo.railo.member.application;
 
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
+import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 public interface MemberAuthService {
 
@@ -13,6 +12,8 @@ public interface MemberAuthService {
 
 	TokenResponse memberNoLogin(MemberNoLoginRequest request);
 
-	void logout(HttpServletRequest request);
+	void logout(String accessToken);
+
+	ReissueTokenResponse reissueAccessToken(String refreshToken);
 
 }

--- a/src/main/java/com/sudo/railo/member/application/MemberService.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberService.java
@@ -4,13 +4,11 @@ import com.sudo.railo.member.application.dto.request.GuestRegisterRequest;
 import com.sudo.railo.member.application.dto.response.GuestRegisterResponse;
 import com.sudo.railo.member.application.dto.response.MemberInfoResponse;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 public interface MemberService {
 
 	GuestRegisterResponse guestRegister(GuestRegisterRequest request);
 
-	void memberDelete(HttpServletRequest request);
+	void memberDelete(String accessToken);
 
 	MemberInfoResponse getMemberInfo();
 }

--- a/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
@@ -17,7 +17,6 @@ import com.sudo.railo.member.domain.Role;
 import com.sudo.railo.member.exception.MemberError;
 import com.sudo.railo.member.infra.MemberRepository;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,7 +54,7 @@ public class MemberServiceImpl implements MemberService {
 	// 회원 삭제 로직
 	@Override
 	@Transactional
-	public void memberDelete(HttpServletRequest request) {
+	public void memberDelete(String accessToken) {
 
 		String currentMemberNo = SecurityUtil.getCurrentMemberNo();
 
@@ -70,7 +69,7 @@ public class MemberServiceImpl implements MemberService {
 		}
 
 		// 로그아웃 수행
-		memberAuthService.logout(request);
+		memberAuthService.logout(accessToken);
 	}
 
 	// 회원 조회 로직

--- a/src/main/java/com/sudo/railo/member/application/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/response/ReissueTokenResponse.java
@@ -1,0 +1,17 @@
+package com.sudo.railo.member.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "accessToken 재발급 응답 DTO")
+public record ReissueTokenResponse(
+
+	@Schema(description = "토큰의 타입 (예: Bearer)", example = "Bearer")
+	String grantType,
+
+	@Schema(description = "발급된 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String accessToken,
+
+	@Schema(description = "액세스 토큰의 만료 시간", example = "1750508812329")
+	Long accessTokenExpiresIn
+) {
+}

--- a/src/main/java/com/sudo/railo/member/docs/AuthControllerDocs.java
+++ b/src/main/java/com/sudo/railo/member/docs/AuthControllerDocs.java
@@ -4,6 +4,7 @@ import com.sudo.railo.global.exception.error.ErrorResponse;
 import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
+import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
 
@@ -41,4 +42,12 @@ public interface AuthControllerDocs {
 		@ApiResponse(responseCode = "403", description = "이미 로그아웃된 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
 	SuccessResponse<?> logout(HttpServletRequest request);
+
+	@Operation(method = "POST", summary = "accessToken 재발급", description = "accessToken 이 만료되었을 때, 토큰을 재발급 받을 수 있도록 합니다.",
+		security = {@SecurityRequirement(name = "bearerAuth")})
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "accessToken 이 성공적으로 재발급되었습니다."),
+		@ApiResponse(responseCode = "403", description = "유효하지 않은 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request);
 }

--- a/src/main/java/com/sudo/railo/member/docs/AuthControllerDocs.java
+++ b/src/main/java/com/sudo/railo/member/docs/AuthControllerDocs.java
@@ -39,7 +39,7 @@ public interface AuthControllerDocs {
 		security = {@SecurityRequirement(name = "bearerAuth")})
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "로그아웃에 성공하였습니다."),
-		@ApiResponse(responseCode = "403", description = "이미 로그아웃된 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+		@ApiResponse(responseCode = "401", description = "이미 로그아웃된 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
 	SuccessResponse<?> logout(HttpServletRequest request);
 
@@ -47,7 +47,7 @@ public interface AuthControllerDocs {
 		security = {@SecurityRequirement(name = "bearerAuth")})
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "accessToken 이 성공적으로 재발급되었습니다."),
-		@ApiResponse(responseCode = "403", description = "유효하지 않은 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+		@ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
 	SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request);
 }

--- a/src/main/java/com/sudo/railo/member/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/member/presentation/AuthController.java
@@ -5,10 +5,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sudo.railo.global.security.jwt.TokenExtractor;
 import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.member.application.MemberAuthService;
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
+import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
 import com.sudo.railo.member.docs.AuthControllerDocs;
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthController implements AuthControllerDocs {
 
 	private final MemberAuthService memberAuthService;
+	private final TokenExtractor tokenExtractor;
 
 	@PostMapping("/signup")
 	public SuccessResponse<SignUpResponse> signUp(@RequestBody @Valid SignUpRequest request) {
@@ -44,9 +47,21 @@ public class AuthController implements AuthControllerDocs {
 	@PostMapping("/logout")
 	public SuccessResponse<?> logout(HttpServletRequest request) {
 
-		memberAuthService.logout(request);
+		String accessToken = tokenExtractor.resolveToken(request);
+
+		memberAuthService.logout(accessToken);
 
 		return SuccessResponse.of(AuthSuccess.LOGOUT_SUCCESS);
+	}
+	
+	@PostMapping("/reissue")
+	public SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request) {
+
+		String refreshToken = tokenExtractor.resolveToken(request);
+
+		ReissueTokenResponse tokenResponse = memberAuthService.reissueAccessToken(refreshToken);
+
+		return SuccessResponse.of(AuthSuccess.REISSUE_TOKEN_SUCCESS, tokenResponse);
 	}
 
 }

--- a/src/main/java/com/sudo/railo/member/presentation/MemberController.java
+++ b/src/main/java/com/sudo/railo/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sudo.railo.global.security.jwt.TokenExtractor;
 import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.member.application.MemberService;
 import com.sudo.railo.member.application.dto.request.GuestRegisterRequest;
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
 	private final MemberService memberService;
+	private final TokenExtractor tokenExtractor;
 
 	@PostMapping("/guest/register")
 	public SuccessResponse<GuestRegisterResponse> guestRegister(@RequestBody @Valid GuestRegisterRequest request) {
@@ -36,7 +38,9 @@ public class MemberController {
 	@DeleteMapping("/members")
 	public SuccessResponse<?> memberDelete(HttpServletRequest request) {
 
-		memberService.memberDelete(request);
+		String accessToken = tokenExtractor.resolveToken(request);
+
+		memberService.memberDelete(accessToken);
 
 		return SuccessResponse.of(MemberSuccess.MEMBER_DELETE_SUCCESS);
 	}

--- a/src/main/java/com/sudo/railo/member/success/AuthSuccess.java
+++ b/src/main/java/com/sudo/railo/member/success/AuthSuccess.java
@@ -13,7 +13,8 @@ public enum AuthSuccess implements SuccessCode {
 
 	SIGN_UP_SUCCESS(HttpStatus.CREATED, "회원가입이 성공적으로 완료되었습니다."),
 	MEMBER_NO_LOGIN_SUCCESS(HttpStatus.OK, "회원번호 로그인이 성공적으로 완료되었습니다."),
-	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다.");
+	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다."),
+	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "AccessToken 이 성공적으로 발급 되었습니다.");
 
 	private final HttpStatus status;
 	private final String message;


### PR DESCRIPTION
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 나열해주세요. ex) - close #1 -->
- close #42 

## 주요 변경 사항 (필수)
<!-- 변경사항을 나열해주세요. -->
- AccessToken 재발급 로직 구현
   - `TokenProvider` 에 reissue 메서드 수정
   - 토큰 재발급 로직에 따라 `MemberAuthService`, `MemberAuthServiceImpl`, `AuthController` 파일에 코드 추가
   - `TokenError` 및 `AuthSuccess` 코드 추가


- Swagger api 문서화를 위한 코드 추가
   - AccessToken 재발급 로직 swagger 코드 추가

- MemberService, MemberServiceImpl, MemberController 코드 리팩토링
   - Service 는 비즈니스 로직에 집중하고 Http 관련 작업은 controller 에서 처리할 수 있도록 코드 리팩토링

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 작성해주세요. -->
### 1. AccessToken 재발급 로직 구현
유저의 RefreshToken 유효시간은 만료 되지 않았지만, AccessToken 유효 시간이 만료 되어 클라이언트 측에 401 에러가 뜬 상황일 때 AccessToken 을 재발급 받을 수 있는 로직을 구현하였습니다.

토큰을 재발급 받는 로직은 다음과 같습니다.
1. 요청 헤더에 `refreshToken` 을 보내 `accessToken` 재발급 요청
2. 로그인된 사용자 정보로 redis 에 저장된 `refreshToken` 정보와 요청으로 넘어온 `refreshToken` 정보가 일치하는지 검증
3. 일치하면 `accessToken` 을 새로 만들어 발급

만약 refreshToken 또한 유효시간이 만료 되었다면 클라이언트 측으로 401 에러가 뜨게 됩니다.
이때, 클라이언트 측에서는 재로그인을 통해 accessToken 및 refreshToken 을 재발급 받을 수 있습니다.

#### accessToken 재발급 성공
<img width="903" alt="스크린샷 2025-06-27 오후 5 12 28" src="https://github.com/user-attachments/assets/792d1a80-0621-4b17-b6ee-b637f004444b" />

<br>

### 2. Swagger Api 문서화를 위한 코드 추가
AccessToken 재발급 로직 구현에 따라 api 문서화를 위한 Swagger 코드 또한 추가하였습니다.

<br>

### 3. `MemberService`, `MemberServiceImpl`, `MemberController` 코드 리팩토링
이번 AccessToken 재발급 로직을 구현하며 윤성님이 저번 pr 에서 의견 주신 것처럼
기존 코드에 Service 계층으로 HttpServletRequest 가 넘어 가는 부분을 리팩토링하게 되었습니다.
이에 따라 `MemberService`, `MemberServiceImpl`, `MemberController` 3가지 파일을 추가로 리팩토링 하게 되었습니다.
이를 통해 Service 는 비즈니스 로직에 집중하고 Http 관련 작업은 Controller 에서 처리할 수 있도록 수정하였습니다 :)

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 작성해주세요. -->
테스트는 Hoppscotch 에 올려두었습니다 :)

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.