### PR TITLE
[FEATURE] 회원번호 찾기 및 비밀번호 찾기 로직 구현

### DIFF
--- a/src/main/java/com/sudo/railo/global/redis/RedisUtil.java
+++ b/src/main/java/com/sudo/railo/global/redis/RedisUtil.java
@@ -18,6 +18,7 @@ public class RedisUtil {
 	private final RedisTemplate<String, String> stringRedisTemplate;
 
 	private static final int AUTH_CODE_EXPIRATION_MINUTES = 5;
+	private static final int MEMBER_NO_EXPIRATION_MINUTES = 5;
 
 	public void save(String key, String value) {
 		stringRedisTemplate.opsForValue().set(key, value);
@@ -84,6 +85,22 @@ public class RedisUtil {
 
 	public void deleteAuthCode(String email) {
 		String key = "authEmail:" + email;
+		stringRedisTemplate.delete(key);
+	}
+
+	/* 회원번호 찾기 관련 */
+	public void saveMemberNo(String email, String memberNo) {
+		String key = "memberNo:" + email;
+		stringRedisTemplate.opsForValue().set(key, memberNo, MEMBER_NO_EXPIRATION_MINUTES, TimeUnit.MINUTES);
+	}
+
+	public String getMemberNo(String email) {
+		String key = "memberNo:" + email;
+		return stringRedisTemplate.opsForValue().get(key);
+	}
+
+	public void deleteMemberNo(String email) {
+		String key = "memberNo:" + email;
 		stringRedisTemplate.delete(key);
 	}
 

--- a/src/main/java/com/sudo/railo/global/security/SecurityConfig.java
+++ b/src/main/java/com/sudo/railo/global/security/SecurityConfig.java
@@ -61,6 +61,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> {
 				auth.requestMatchers("/", "/auth/signup", "/auth/login").permitAll()
 					.requestMatchers(HttpMethod.POST, "/auth/emails/**").permitAll()
+					.requestMatchers(HttpMethod.POST, "/auth/member-no/**", "/auth/password/**").permitAll()
 					.requestMatchers("/api/v1/guest/register", "/api/v1/trains/**").permitAll()
 					.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
 					.requestMatchers("/actuator/**").permitAll()

--- a/src/main/java/com/sudo/railo/global/security/TokenError.java
+++ b/src/main/java/com/sudo/railo/global/security/TokenError.java
@@ -17,7 +17,8 @@ public enum TokenError implements ErrorCode {
 	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "T_004"),
 	INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_005"),
 	AUTHORITY_NOT_FOUND("권한 정보가 없는 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_006"),
-	NOT_EQUALS_REFRESH_TOKEN("리프레시 토큰이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_007");
+	NOT_EQUALS_REFRESH_TOKEN("리프레시 토큰이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_007"),
+	INVALID_TEMPORARY_TOKEN_USAGE("임시토큰으로 해당 요청에 접근할 수 없습니다.", HttpStatus.UNAUTHORIZED, "T_008");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
@@ -39,6 +39,7 @@ public class TokenProvider {
 	private static final String BEARER_TYPE = "Bearer";
 	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
 	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+	private static final long TEMPORARY_TOKEN_EXPIRE_TIME = 1000 * 60 * 5; // 5분
 	private final Key key;
 
 	public TokenProvider(
@@ -119,6 +120,18 @@ public class TokenProvider {
 			newAccessToken,
 			accessTokenExpiresIn.getTime()
 		);
+	}
+
+	// 임시 토큰 발급 (5분)
+	public String generateTemporaryToken(String memberNo) {
+		long now = System.currentTimeMillis();
+		Date temporaryTokenExpiresIn = new Date(now + TEMPORARY_TOKEN_EXPIRE_TIME);
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setSubject(memberNo)
+			.setExpiration(temporaryTokenExpiresIn)
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
 	}
 
 	// 토큰에 등록된 클레임의 sub에서 해당 회원 번호 추출

--- a/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/global/security/jwt/TokenProvider.java
@@ -129,6 +129,7 @@ public class TokenProvider {
 		return Jwts.builder()
 			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
 			.setSubject(memberNo)
+			.claim("tokenType", "TEMPORARY_TOKEN")
 			.setExpiration(temporaryTokenExpiresIn)
 			.signWith(key, SignatureAlgorithm.HS512)
 			.compact();
@@ -196,7 +197,7 @@ public class TokenProvider {
 	}
 
 	// AccessToken에서 클레임을 추출하는 메서드
-	private Claims parseClaims(String accessToken) {
+	protected Claims parseClaims(String accessToken) {
 		try {
 			return Jwts.parserBuilder()
 				.setSigningKey(key)

--- a/src/main/java/com/sudo/railo/member/application/MemberAuthService.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberAuthService.java
@@ -7,7 +7,6 @@ import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.SendCodeResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
-import com.sudo.railo.member.application.dto.response.VerifyCodeResponse;
 
 public interface MemberAuthService {
 
@@ -21,6 +20,6 @@ public interface MemberAuthService {
 
 	SendCodeResponse sendAuthCode(String email);
 
-	VerifyCodeResponse verifyAuthCode(VerifyCodeRequest request);
+	boolean verifyAuthCode(VerifyCodeRequest request);
 
 }

--- a/src/main/java/com/sudo/railo/member/application/MemberAuthServiceImpl.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberAuthServiceImpl.java
@@ -25,7 +25,6 @@ import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.SendCodeResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
-import com.sudo.railo.member.application.dto.response.VerifyCodeResponse;
 import com.sudo.railo.member.domain.Member;
 import com.sudo.railo.member.domain.MemberDetail;
 import com.sudo.railo.member.domain.Membership;
@@ -129,7 +128,7 @@ public class MemberAuthServiceImpl implements MemberAuthService {
 	}
 
 	@Override
-	public VerifyCodeResponse verifyAuthCode(VerifyCodeRequest request) {
+	public boolean verifyAuthCode(VerifyCodeRequest request) {
 		// redis 에서 저장해둔 인증 코드 get
 		String findCode = redisUtil.getAuthCode(request.email());
 		boolean isVerified = request.authCode().equals(findCode);
@@ -138,7 +137,7 @@ public class MemberAuthServiceImpl implements MemberAuthService {
 			redisUtil.deleteAuthCode(request.email());
 		}
 
-		return new VerifyCodeResponse(isVerified);
+		return isVerified;
 	}
 
 	private String createAuthCode() {

--- a/src/main/java/com/sudo/railo/member/application/MemberService.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberService.java
@@ -1,11 +1,15 @@
 package com.sudo.railo.member.application;
 
+import com.sudo.railo.member.application.dto.request.FindMemberNoRequest;
 import com.sudo.railo.member.application.dto.request.GuestRegisterRequest;
 import com.sudo.railo.member.application.dto.request.UpdateEmailRequest;
 import com.sudo.railo.member.application.dto.request.UpdatePasswordRequest;
 import com.sudo.railo.member.application.dto.request.UpdatePhoneNumberRequest;
+import com.sudo.railo.member.application.dto.request.VerifyCodeRequest;
 import com.sudo.railo.member.application.dto.response.GuestRegisterResponse;
 import com.sudo.railo.member.application.dto.response.MemberInfoResponse;
+import com.sudo.railo.member.application.dto.response.SendCodeResponse;
+import com.sudo.railo.member.application.dto.response.VerifyMemberNoResponse;
 
 public interface MemberService {
 
@@ -22,5 +26,9 @@ public interface MemberService {
 	void updatePassword(UpdatePasswordRequest request);
 
 	String getMemberEmail(String memberNo);
+
+	SendCodeResponse requestFindMemberNo(FindMemberNoRequest request);
+
+	VerifyMemberNoResponse verifyFindMemberNo(VerifyCodeRequest request);
 
 }

--- a/src/main/java/com/sudo/railo/member/application/MemberService.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package com.sudo.railo.member.application;
 
 import com.sudo.railo.member.application.dto.request.FindMemberNoRequest;
+import com.sudo.railo.member.application.dto.request.FindPasswordRequest;
 import com.sudo.railo.member.application.dto.request.GuestRegisterRequest;
 import com.sudo.railo.member.application.dto.request.UpdateEmailRequest;
 import com.sudo.railo.member.application.dto.request.UpdatePasswordRequest;
@@ -9,6 +10,7 @@ import com.sudo.railo.member.application.dto.request.VerifyCodeRequest;
 import com.sudo.railo.member.application.dto.response.GuestRegisterResponse;
 import com.sudo.railo.member.application.dto.response.MemberInfoResponse;
 import com.sudo.railo.member.application.dto.response.SendCodeResponse;
+import com.sudo.railo.member.application.dto.response.TemporaryTokenResponse;
 import com.sudo.railo.member.application.dto.response.VerifyMemberNoResponse;
 
 public interface MemberService {
@@ -30,5 +32,9 @@ public interface MemberService {
 	SendCodeResponse requestFindMemberNo(FindMemberNoRequest request);
 
 	VerifyMemberNoResponse verifyFindMemberNo(VerifyCodeRequest request);
+
+	SendCodeResponse requestFindPassword(FindPasswordRequest request);
+
+	TemporaryTokenResponse verifyFindPassword(VerifyCodeRequest request);
 
 }

--- a/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
@@ -225,7 +225,7 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	private String verifyCodeAndGetMemberNo(VerifyCodeRequest request) {
-		Boolean isVerified = memberAuthService.verifyAuthCode(request);
+		boolean isVerified = memberAuthService.verifyAuthCode(request);
 
 		if (!isVerified) { // 인증 실패 시
 			throw new BusinessException(AuthError.INVALID_AUTH_CODE);

--- a/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
@@ -171,7 +171,7 @@ public class MemberServiceImpl implements MemberService {
 	@Transactional(readOnly = true)
 	public SendCodeResponse requestFindMemberNo(FindMemberNoRequest request) {
 
-		Member member = memberRepository.findByNameAndPhoneNumberAndRole(request.name(), request.phoneNumber())
+		Member member = memberRepository.findMemberByNameAndPhoneNumber(request.name(), request.phoneNumber())
 			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
 
 		String memberEmail = member.getMemberDetail().getEmail();

--- a/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/sudo/railo/member/application/MemberServiceImpl.java
@@ -21,7 +21,6 @@ import com.sudo.railo.member.application.dto.response.GuestRegisterResponse;
 import com.sudo.railo.member.application.dto.response.MemberInfoResponse;
 import com.sudo.railo.member.application.dto.response.SendCodeResponse;
 import com.sudo.railo.member.application.dto.response.TemporaryTokenResponse;
-import com.sudo.railo.member.application.dto.response.VerifyCodeResponse;
 import com.sudo.railo.member.application.dto.response.VerifyMemberNoResponse;
 import com.sudo.railo.member.domain.Member;
 import com.sudo.railo.member.domain.MemberDetail;
@@ -194,7 +193,7 @@ public class MemberServiceImpl implements MemberService {
 	@Override
 	@Transactional(readOnly = true)
 	public SendCodeResponse requestFindPassword(FindPasswordRequest request) {
-		
+
 		Member member = memberRepository.findByMemberNo(request.memberNo())
 			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
 
@@ -226,9 +225,9 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	private String verifyCodeAndGetMemberNo(VerifyCodeRequest request) {
-		VerifyCodeResponse verifyCodeResponse = memberAuthService.verifyAuthCode(request);
+		Boolean isVerified = memberAuthService.verifyAuthCode(request);
 
-		if (!verifyCodeResponse.isVerified()) { // 인증 실패 시
+		if (!isVerified) { // 인증 실패 시
 			throw new BusinessException(AuthError.INVALID_AUTH_CODE);
 		}
 

--- a/src/main/java/com/sudo/railo/member/application/dto/request/FindMemberNoRequest.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/request/FindMemberNoRequest.java
@@ -1,0 +1,19 @@
+package com.sudo.railo.member.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "회원번호 찾기 요청 DTO")
+public record FindMemberNoRequest(
+
+	@Schema(description = "사용자의 이름", example = "홍길동")
+	@NotBlank(message = "이름은 필수입니다.")
+	String name,
+
+	@Schema(description = "전화번호, '-' 없이 11자리 숫자로 입력", example = "01012345678")
+	@NotBlank(message = "전화번호는 필수입니다.")
+	@Pattern(regexp = "^[0-9]{11}$", message = "전화번호는 -를 제외한 11자리 숫자만 가능합니다.")
+	String phoneNumber
+) {
+}

--- a/src/main/java/com/sudo/railo/member/application/dto/request/FindPasswordRequest.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/request/FindPasswordRequest.java
@@ -1,0 +1,17 @@
+package com.sudo.railo.member.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "비밀번호 찾기 요청 DTO")
+public record FindPasswordRequest(
+
+	@Schema(description = "사용자의 이름", example = "홍길동")
+	@NotBlank(message = "이름은 필수입니다.")
+	String name,
+
+	@Schema(description = "회원의 고유 번호", example = "202506260001")
+	@NotBlank(message = "회원번호는 필수입니다.")
+	String memberNo
+) {
+}

--- a/src/main/java/com/sudo/railo/member/application/dto/response/TemporaryTokenResponse.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/response/TemporaryTokenResponse.java
@@ -1,0 +1,11 @@
+package com.sudo.railo.member.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "임시 토큰 발급 DTO")
+public record TemporaryTokenResponse(
+
+	@Schema(description = "임시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String temporaryToken
+) {
+}

--- a/src/main/java/com/sudo/railo/member/application/dto/response/VerifyMemberNoResponse.java
+++ b/src/main/java/com/sudo/railo/member/application/dto/response/VerifyMemberNoResponse.java
@@ -1,0 +1,11 @@
+package com.sudo.railo.member.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원번호 찾기 검증 응답 DTO")
+public record VerifyMemberNoResponse(
+
+	@Schema(description = "찾아온 회원 번호", example = "202506260001")
+	String memberNo
+) {
+}

--- a/src/main/java/com/sudo/railo/member/docs/AuthControllerDocs.java
+++ b/src/main/java/com/sudo/railo/member/docs/AuthControllerDocs.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 
 import com.sudo.railo.global.exception.error.ErrorResponse;
 import com.sudo.railo.global.success.SuccessResponse;
+import com.sudo.railo.member.application.dto.request.FindMemberNoRequest;
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SendCodeRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
@@ -13,6 +14,7 @@ import com.sudo.railo.member.application.dto.response.SendCodeResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
 import com.sudo.railo.member.application.dto.response.VerifyCodeResponse;
+import com.sudo.railo.member.application.dto.response.VerifyMemberNoResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -78,4 +80,18 @@ public interface AuthControllerDocs {
 		@ApiResponse(responseCode = "400", description = "요청 본문이 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
 	ResponseEntity<VerifyCodeResponse> verifyAuthCode(VerifyCodeRequest request);
+
+	@Operation(method = "POST", summary = "회원번호 찾기 요청", description = "회원번호를 찾기 위한 요청을 받고, 본인인증을 위한 이메일 인증 코드를 전송합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "이메일 인증 코드 전송을 성공했습니다."),
+		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<SendCodeResponse> requestFindMemberNo(FindMemberNoRequest request);
+
+	@Operation(method = "POST", summary = "회원번호 찾기 인증코드 검증 요청", description = "회원번호를 찾기 위해 인증코드 검증 후, 성공하면 회원번호를 응답으로 보냅니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "이메일 인증 코드 검증에 성공했습니다."),
+		@ApiResponse(responseCode = "401", description = "인증 코드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<VerifyMemberNoResponse> verifyFindMemberNo(VerifyCodeRequest request);
 }

--- a/src/main/java/com/sudo/railo/member/docs/AuthControllerDocs.java
+++ b/src/main/java/com/sudo/railo/member/docs/AuthControllerDocs.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import com.sudo.railo.global.exception.error.ErrorResponse;
 import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.member.application.dto.request.FindMemberNoRequest;
+import com.sudo.railo.member.application.dto.request.FindPasswordRequest;
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SendCodeRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
@@ -12,6 +13,7 @@ import com.sudo.railo.member.application.dto.request.VerifyCodeRequest;
 import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.SendCodeResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
+import com.sudo.railo.member.application.dto.response.TemporaryTokenResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
 import com.sudo.railo.member.application.dto.response.VerifyCodeResponse;
 import com.sudo.railo.member.application.dto.response.VerifyMemberNoResponse;
@@ -94,4 +96,19 @@ public interface AuthControllerDocs {
 		@ApiResponse(responseCode = "401", description = "인증 코드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
 	SuccessResponse<VerifyMemberNoResponse> verifyFindMemberNo(VerifyCodeRequest request);
+
+	@Operation(method = "POST", summary = "비밀번호 찾기 요청", description = "비밀번호를 찾기 위한 요청을 받고, 본인인증을 위한 이메일 인증 코드를 전송합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "이메일 인증 코드 전송을 성공했습니다."),
+		@ApiResponse(responseCode = "400", description = "이름이 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<SendCodeResponse> requestFindPassword(FindPasswordRequest request);
+
+	@Operation(method = "POST", summary = "비밀번호 찾기 인증코드 검증 요청", description = "비밀번호를 찾기 위해 인증코드 검증 후, 성공하면 유효시간이 5분인 임시토큰을 응답으로 보냅니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "이메일 인증 코드 검증에 성공했습니다."),
+		@ApiResponse(responseCode = "401", description = "인증 코드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<TemporaryTokenResponse> verifyFindPassword(VerifyCodeRequest request);
 }

--- a/src/main/java/com/sudo/railo/member/exception/AuthError.java
+++ b/src/main/java/com/sudo/railo/member/exception/AuthError.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuthError implements ErrorCode {
 
-	SEND_EMAIL_FAIL("인증 이메일 전송이 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "E_001");
+	SEND_EMAIL_FAIL("인증 이메일 전송이 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "E_001"),
+	INVALID_AUTH_CODE("인증 코드가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "E_002");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/railo/member/exception/MemberError.java
+++ b/src/main/java/com/sudo/railo/member/exception/MemberError.java
@@ -19,7 +19,8 @@ public enum MemberError implements ErrorCode {
 	SAME_PHONE_NUMBER("현재 사용하는 휴대폰 번호와 동일합니다.", HttpStatus.CONFLICT, "M_006"),
 	DUPLICATE_PHONE_NUMBER("이미 사용 중인 휴대폰 번호입니다.", HttpStatus.CONFLICT, "M_007"),
 	SAME_EMAIL("현재 사용중인 이메일과 동일합니다.", HttpStatus.CONFLICT, "M_008"),
-	SAME_PASSWORD("현재 사용중인 비밀번호와 동일합니다.", HttpStatus.CONFLICT, "M_009");
+	SAME_PASSWORD("현재 사용중인 비밀번호와 동일합니다.", HttpStatus.CONFLICT, "M_009"),
+	NAME_MISMATCH("이름이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "M_010");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/railo/member/infra/MemberRepositoryCustom.java
+++ b/src/main/java/com/sudo/railo/member/infra/MemberRepositoryCustom.java
@@ -6,4 +6,6 @@ import com.sudo.railo.member.domain.Member;
 
 public interface MemberRepositoryCustom {
 	Optional<Member> findByMemberNo(String memberNo);
+
+	Optional<Member> findByNameAndPhoneNumberAndRole(String name, String phoneNumber);
 }

--- a/src/main/java/com/sudo/railo/member/infra/MemberRepositoryCustom.java
+++ b/src/main/java/com/sudo/railo/member/infra/MemberRepositoryCustom.java
@@ -7,5 +7,5 @@ import com.sudo.railo.member.domain.Member;
 public interface MemberRepositoryCustom {
 	Optional<Member> findByMemberNo(String memberNo);
 
-	Optional<Member> findByNameAndPhoneNumberAndRole(String name, String phoneNumber);
+	Optional<Member> findMemberByNameAndPhoneNumber(String name, String phoneNumber);
 }

--- a/src/main/java/com/sudo/railo/member/infra/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/sudo/railo/member/infra/MemberRepositoryCustomImpl.java
@@ -29,7 +29,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 	}
 
 	@Override
-	public Optional<Member> findByNameAndPhoneNumberAndRole(String name, String phoneNumber) {
+	public Optional<Member> findMemberByNameAndPhoneNumber(String name, String phoneNumber) {
 
 		QMember member = QMember.member;
 

--- a/src/main/java/com/sudo/railo/member/infra/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/sudo/railo/member/infra/MemberRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sudo.railo.member.domain.Member;
 import com.sudo.railo.member.domain.QMember;
 import com.sudo.railo.member.domain.QMemberDetail;
+import com.sudo.railo.member.domain.Role;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,5 +26,20 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 			.where(member.memberDetail.memberNo.eq(memberNo))
 			.fetchOne();
 		return Optional.ofNullable(result);
+	}
+
+	@Override
+	public Optional<Member> findByNameAndPhoneNumberAndRole(String name, String phoneNumber) {
+
+		QMember member = QMember.member;
+
+		return Optional.ofNullable(queryFactory
+			.selectFrom(member)
+			.where(
+				member.name.eq(name),
+				member.phoneNumber.eq(phoneNumber),
+				member.role.eq(Role.MEMBER)
+			)
+			.fetchOne());
 	}
 }

--- a/src/main/java/com/sudo/railo/member/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/member/presentation/AuthController.java
@@ -105,7 +105,8 @@ public class AuthController implements AuthControllerDocs {
 	@PostMapping("/emails/verify")
 	public ResponseEntity<VerifyCodeResponse> verifyAuthCode(@RequestBody @Valid VerifyCodeRequest request) {
 
-		VerifyCodeResponse response = memberAuthService.verifyAuthCode(request);
+		boolean isVerified = memberAuthService.verifyAuthCode(request);
+		VerifyCodeResponse response = new VerifyCodeResponse(isVerified);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/sudo/railo/member/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/member/presentation/AuthController.java
@@ -11,6 +11,7 @@ import com.sudo.railo.global.security.jwt.TokenExtractor;
 import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.member.application.MemberAuthService;
 import com.sudo.railo.member.application.MemberService;
+import com.sudo.railo.member.application.dto.request.FindMemberNoRequest;
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SendCodeRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
@@ -20,6 +21,7 @@ import com.sudo.railo.member.application.dto.response.SendCodeResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
 import com.sudo.railo.member.application.dto.response.VerifyCodeResponse;
+import com.sudo.railo.member.application.dto.response.VerifyMemberNoResponse;
 import com.sudo.railo.member.docs.AuthControllerDocs;
 import com.sudo.railo.member.success.AuthSuccess;
 
@@ -104,6 +106,23 @@ public class AuthController implements AuthControllerDocs {
 		VerifyCodeResponse response = memberAuthService.verifyAuthCode(request);
 
 		return ResponseEntity.ok(response);
+	}
+
+	/* 회원 번호 찾기 with 이메일 인증 */
+	@PostMapping("/member-no")
+	public SuccessResponse<SendCodeResponse> requestFindMemberNo(@RequestBody @Valid FindMemberNoRequest request) {
+
+		SendCodeResponse response = memberService.requestFindMemberNo(request);
+
+		return SuccessResponse.of(AuthSuccess.SEND_CODE_SUCCESS, response);
+	}
+
+	@PostMapping("/member-no/verify")
+	public SuccessResponse<VerifyMemberNoResponse> verifyFindMemberNo(@RequestBody @Valid VerifyCodeRequest request) {
+
+		VerifyMemberNoResponse response = memberService.verifyFindMemberNo(request);
+
+		return SuccessResponse.of(AuthSuccess.VERIFY_CODE_SUCCESS, response);
 	}
 
 }

--- a/src/main/java/com/sudo/railo/member/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/member/presentation/AuthController.java
@@ -12,6 +12,7 @@ import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.member.application.MemberAuthService;
 import com.sudo.railo.member.application.MemberService;
 import com.sudo.railo.member.application.dto.request.FindMemberNoRequest;
+import com.sudo.railo.member.application.dto.request.FindPasswordRequest;
 import com.sudo.railo.member.application.dto.request.MemberNoLoginRequest;
 import com.sudo.railo.member.application.dto.request.SendCodeRequest;
 import com.sudo.railo.member.application.dto.request.SignUpRequest;
@@ -19,6 +20,7 @@ import com.sudo.railo.member.application.dto.request.VerifyCodeRequest;
 import com.sudo.railo.member.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.member.application.dto.response.SendCodeResponse;
 import com.sudo.railo.member.application.dto.response.SignUpResponse;
+import com.sudo.railo.member.application.dto.response.TemporaryTokenResponse;
 import com.sudo.railo.member.application.dto.response.TokenResponse;
 import com.sudo.railo.member.application.dto.response.VerifyCodeResponse;
 import com.sudo.railo.member.application.dto.response.VerifyMemberNoResponse;
@@ -121,6 +123,23 @@ public class AuthController implements AuthControllerDocs {
 	public SuccessResponse<VerifyMemberNoResponse> verifyFindMemberNo(@RequestBody @Valid VerifyCodeRequest request) {
 
 		VerifyMemberNoResponse response = memberService.verifyFindMemberNo(request);
+
+		return SuccessResponse.of(AuthSuccess.VERIFY_CODE_SUCCESS, response);
+	}
+
+	/* 비밀번호 찾기 with 이메일 인증 */
+	@PostMapping("/password")
+	public SuccessResponse<SendCodeResponse> requestFindPassword(@RequestBody @Valid FindPasswordRequest request) {
+
+		SendCodeResponse response = memberService.requestFindPassword(request);
+
+		return SuccessResponse.of(AuthSuccess.SEND_CODE_SUCCESS, response);
+	}
+
+	@PostMapping("/password/verify")
+	public SuccessResponse<TemporaryTokenResponse> verifyFindPassword(@RequestBody @Valid VerifyCodeRequest request) {
+
+		TemporaryTokenResponse response = memberService.verifyFindPassword(request);
 
 		return SuccessResponse.of(AuthSuccess.VERIFY_CODE_SUCCESS, response);
 	}

--- a/src/main/java/com/sudo/railo/member/success/AuthSuccess.java
+++ b/src/main/java/com/sudo/railo/member/success/AuthSuccess.java
@@ -17,7 +17,8 @@ public enum AuthSuccess implements SuccessCode {
 	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "AccessToken 이 성공적으로 발급 되었습니다."),
 
 	// 이메일 인증 관련
-	SEND_CODE_SUCCESS(HttpStatus.OK, "이메일 인증 코드 전송을 성공했습니다.");
+	SEND_CODE_SUCCESS(HttpStatus.OK, "이메일 인증 코드 전송을 성공했습니다."),
+	VERIFY_CODE_SUCCESS(HttpStatus.OK, "이메일 인증 코드 검증에 성공했습니다.");
 
 	private final HttpStatus status;
 	private final String message;


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #17 

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 회원 번호 찾기 로직 구현
- 비밀 번호 찾기 로직 구현
- securityConfig 경로 추가
- 기존 이메일 검증 로직 반환 타입 변경
- 구현 기능 Swagger 문서화

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
### 1. 회원 번호 찾기 로직 구현

현재 회원 번호 찾기 로직 흐름은 다음과 같습니다.
1. 회원의 `이름`, `휴대폰 번호`를 요청으로 받음
2. DB에 해당 정보를 가진 회원이 있는지 확인
3. 일치 하는 회원이 있다면 회원번호를 레디스에 잠시 저장 (유효시간 5분)
4. 찾아온 회원 정보에 있는 이메일로 이메일 인증 코드를 보내고, 인증 코드를 발송한 이메일 주소를 response 로 반환
5. 검증을 위해 클라이언트로부터 `이메일`과 `인증코드`를 받아 검증 진행 후, 일치하면 회원번호 반환

미리 구현해 놓은 이메일 인증 로직을 가져와 본인확인 후, 회원 번호를 발급할 수 있도록 구현하였습니다.

#### 회원번호 찾기 요청 테스트
![스크린샷 2025-07-08 오후 2 25 48](https://github.com/user-attachments/assets/6f4e7ad8-9b62-4134-9631-23569f1fb02b)

#### 회원번호 검증 요청 테스트
![스크린샷 2025-07-08 오후 2 33 04](https://github.com/user-attachments/assets/d8de5084-4a61-4b04-990a-dac4dcbd22ae)


<br>

### 2. 비밀 번호 찾기 로직 구현
기능명을 '비밀번호 찾기' 로 해놓았지만,
코레일 서비스와 같이 본인 인증 후 비밀번호를 변경할 수 있는 페이지로 리다이렉트 할 수 있는 시나리오로 생각하고 로직을 구현하였습니다.

비밀 번호 찾기 로직 흐름은 다음과 같습니다.
1. 회원의 `이름`, `회원번호`를 요청으로 받음
2. DB 에 해당 정보를 가진 회원이 있는지 확인
3. 일치하는 회원이 있다면 회원 정보에 있는 이메일로 인증 코드를 보내고, 인증 코드를 발송한 이메일 주소를 response 로 반환
4. 검증을 위해 클라이언트로부터 이메일과 인증코드를 받아 검증 진행 후, 일치하면 성공메세지와 함께 임시 토큰을 발급 (비밀번호 변경 요청 엔드포인트 접근 시 필요. 유효시간 5분) 

#### 비밀번호 찾기 요청 테스트
![스크린샷 2025-07-08 오후 2 33 48](https://github.com/user-attachments/assets/42e5421a-d8e7-45f6-91bf-3e4e4d0a2e16)

#### 비밀번호 검증 요청 테스트
![스크린샷 2025-07-08 오후 2 34 37](https://github.com/user-attachments/assets/38b220b8-e071-4308-b876-5ed5f1e9a4a2)

<br>

### 3. securityConfig 경로 추가
회원번호 찾기 및 비밀번호 찾기는 로그인 되기 전 사용자가 본인의 정보를 찾을 수 있도록 SecurityConfig 에 해당 엔드포인트를 추가해 두었습니다.

<br>

### 4. 기존 이메일 검증 로직 반환 타입 변경
이메일 인증 로직 중 `MemberAuthService` 에 있는 verifyAuthCode() 메서드 부분의 반환 타입을 dto 타입이 아닌 boolean 타입으로 변경하여 다른 회원 서비스에서도 재사용이 가능하도록 수정하였습니다.

<br>

### 5. 구현 기능 Swagger 문서화
해당 기능 api 문서화를 위해 swagger 코드를 추가하였습니다

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
자세한 테스트는 Hoppscotch 에 올려두었으니 확인해주세요 :)

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.