### PR TITLE
[CHORE] ArgoCD 세팅

### DIFF
--- a/k8s-argocd/argocd-application.yml
+++ b/k8s-argocd/argocd-application.yml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application  # 각종 환경 설정 적용
+metadata:
+  name: raillo-backend
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/goorm-sudo/raillo-backend
+    targetRevision: main
+    path: k8s # Argo CD는 내부적으로 Git repo를 clone 한 뒤 path에 지정된 상대 경로에서 YAML 파일을 찾기 때문에 /를 빼야함
+  destination:
+    # https://kubernetes.default.svc: Argo CD 자체가 설치된 클러스터의 내부 주소
+    server: https://kubernetes.default.svc
+    namespace: raillo    # 한 개의 Application 당 한 개의 namespace 담당
+  syncPolicy:
+    # Argo CD가 개발자가 직접 명령하지 않아도 자동으로 GitHub에 있는 매니페스트를 클러스터에 적용
+    automated:
+      # GitHub에서 삭제된 리소스는 클러스터에서도 자동 삭제
+      prune: true
+      # 클러스터 안에서 수동으로 리소스가 변경되면, GitHub에 있는 원래 상태로 자동 복구
+      selfHeal: true

--- a/k8s-argocd/argocd-application.yml
+++ b/k8s-argocd/argocd-application.yml
@@ -1,3 +1,6 @@
+# ArgoCD Pod, 핵심 컴포넌트 설치
+# kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
 apiVersion: argoproj.io/v1alpha1
 kind: Application  # 각종 환경 설정 적용
 metadata:

--- a/k8s-argocd/argocd-https.yml
+++ b/k8s-argocd/argocd-https.yml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argo-raillo-com-tls
+  namespace: argocd
+spec:
+  secretName: argo-raillo-com-tls
+  duration: 2160h #90day
+  renewBefore: 360h #before 15day
+  issuerRef: # ClusterIssuer 는 기존 것을 재사용
+    name: raillo-issuer
+    kind: ClusterIssuer  # 어떤 인증 기관에서 어떤 인증서 종류를 발급받을 것인지에 대한 정의
+  commonName: argo.raillo.shop
+  dnsNames:
+    - argo.raillo.shop  # Ingress 의 host 이름과 일치

--- a/k8s-argocd/argocd-ingress.yml
+++ b/k8s-argocd/argocd-ingress.yml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server-ingress
+  namespace: argocd
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: raillo-issuer # https.yml의 issuer 이름과 일치
+spec:
+  # argocd pod에 --insecure로 https를 사용하지 않는다고 명시해놓았기 때문에
+  # ingress에서 인증처리
+  tls:
+    - hosts:
+        - argo.raillo.shop
+      secretName: argo-raillo-com-tls  # 해당 host에 해당 이름으로 인증서에 secret 생성
+  rules:
+    - host: argo.raillo.shop
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server  # argocd-server의 80포트로 라우팅
+                port:
+                  number: 80


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #100

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- ArgoCD 적용 Application 스크립트 적용 - `argocd-application.yml`
- ArgoCD UI 를 외부에서 접속하기 위한 Ingress 스크립트 적용 `argocd-ingress.yml`
- https 로 접속하기 위한 Certificate 스크립트 적용 - `argocd-https.yml`

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
Github에 있는 소스코드를 기반으로 Kubernetes 인프라 환경을 동기화하기 위해 ArgoCD를 세팅하였습니다.
ArgoCD가 `/k8s` 폴더 하위 소스만을 추적하도록 세팅했습니다.
해당 설정으로 Github의 `/k8s` 하위 yml 소스들과 실제 클러스터가 sync가 안맞으면 ArgoCD가 github 기준으로 비교하여 강제로 sync를 맞춥니다.

로컬에서 아래와 같이 replicas를 임시로 늘려보는 테스트를 통해 Github 소스코드와 다른 경우 강제로 종료시키는 것을 확인했습니다.
<img width="1004" height="400" alt="image" src="https://github.com/user-attachments/assets/ae04307e-b2dc-4760-9c5f-63731a1dd781" />


해당 파일들은 모두 Local에서 적용하여 테스트 완료된 상태입니다.
argocd 관련 폴더인 `k8s-argocd` 하위 스크립트는 ArgoCD로 추적하고 있지 않으며, 단순 기록 및 보관을 위해 Github에 업로드하게 되었습니다.

ArgoCD UI는 아래 도메인으로 접속하여 확인할 수 있습니다. ID/PW는 Discord에 공유하겠습니다.
- https://argo.raillo.shop/
<img width="1795" height="1005" alt="image" src="https://github.com/user-attachments/assets/0a98c621-506c-4573-830b-ebb170e8dfdc" />


## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.