### PR TITLE
[CHORE] 타임존 일관성 확보: Dockerfile 및 Spring Jackson에 Asia/Seoul 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,14 @@ RUN ./gradlew bootJar
 
 # Stage 2: 실행용 (경량 이미지에 결과물만 포함)
 FROM openjdk:17-jdk-alpine
+
+# 1. 타임존 데이터 설치
+RUN apk add --no-cache tzdata
+# 2. 시스템 타임존을 Asia/Seoul로 설정
+ENV TZ=Asia/Seoul
+# 3. JVM도 명시적으로 Asia/Seoul로 고정
+ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul"
+
 WORKDIR /app
 COPY --from=stage1 /app/build/libs/*.jar app.jar
 # 파일이 변경되지 않으면 Docker 빌드 캐시로 인해 재사용됨

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,6 +6,9 @@ spring:
       - optional:file:.env[.properties]
       - classpath:train-template.yml
 
+  jackson:
+    time-zone: Asia/Seoul
+  
   data:
     redis:
       host: redis-service   # k8s의 redis 서비스명


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #129

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- Image에 Timezone 설정
- Jackson 에 Timezone 설정 

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
EKS 서버를 거쳐 DB에서 조회 시 UTC로 반환되는 문제가 있어 Image와 Jackson의 LocalDate DTO 변환에 Asia/Seoul을 설정했습니다.

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.