### PR TITLE
[BUG] 상행 열차에서 구간 겹침 조건이 잘못되어 좌석 계산 오류 수정

### DIFF
--- a/src/main/java/com/sudo/railo/train/infrastructure/SeatReservationRepositoryCustomImpl.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/SeatReservationRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sudo.railo.booking.domain.QSeatReservation;
 import com.sudo.railo.booking.domain.SeatStatus;
@@ -32,6 +33,24 @@ public class SeatReservationRepositoryCustomImpl implements SeatReservationRepos
 		QSeat s = QSeat.seat;
 		QTrainCar tc = QTrainCar.trainCar;
 
+		/**
+		 * 상행 / 하행 방향 판단 : 출발역 < 도착역이면 하행, 아니면 상행
+		 * 역 ID가 낮은 쪽 → 높은 쪽: 하행 (예: 서울(10) → 부산(50))
+		 * 역 ID가 높은 쪽 → 낮은 쪽: 상행 (예: 부산(50) → 서울(10))
+		 */
+		boolean isDownward = departureStationId < arrivalStationId;
+
+		// 구간 겹침 조건 정의
+		// 예약 구간: [기존출발 ~ 기존도착]
+		// 요청 구간: [검색출발 ~ 검색도착]
+		// 겹침 조건: 기존출발 < 검색도착 AND 기존도착 > 검색출발 (하행 기준)
+		//           기존출발 > 검색도착 AND 기존도착 < 검색출발 (상행 기준)
+		BooleanExpression overlapCondition = isDownward
+			? reservation.departureStation.id.lt(arrivalStationId)
+			.and(reservation.arrivalStation.id.gt(departureStationId)) // 하행
+			: reservation.departureStation.id.gt(arrivalStationId)
+			.and(reservation.arrivalStation.id.lt(departureStationId)); // 상행
+
 		return queryFactory
 			.select(Projections.constructor(
 				SeatReservationInfo.class,
@@ -47,10 +66,7 @@ public class SeatReservationRepositoryCustomImpl implements SeatReservationRepos
 				reservation.trainSchedule.id.eq(trainScheduleId),
 				reservation.seatStatus.in(SeatStatus.RESERVED, SeatStatus.LOCKED),
 				reservation.isStanding.isFalse(),
-
-				// 기존출발 < 검색도착 AND 기존도착 > 검색출발
-				reservation.departureStation.id.lt(arrivalStationId)               // 예약출발 < 검색도착 (less than)
-					.and(reservation.arrivalStation.id.gt(departureStationId))   // 예약도착 > 검색출발 (greater than)
+				overlapCondition  // 구간 겹침 조건
 			)
 			.fetch();
 	}

--- a/src/main/java/com/sudo/railo/train/infrastructure/TrainCarQueryRepositoryCustomImpl.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/TrainCarQueryRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sudo.railo.booking.domain.QSeatReservation;
@@ -38,6 +39,24 @@ public class TrainCarQueryRepositoryCustomImpl implements TrainCarQueryRepositor
 		QSeat s = QSeat.seat;
 		QSeatReservation sr = QSeatReservation.seatReservation;
 
+		/**
+		 * 상행 / 하행 방향 판단 : 출발역 < 도착역이면 하행, 아니면 상행
+		 * 역 ID가 낮은 쪽 → 높은 쪽: 하행 (예: 서울(10) → 부산(50))
+		 * 역 ID가 높은 쪽 → 낮은 쪽: 상행 (예: 부산(50) → 서울(10))
+		 */
+		boolean isDownward = departureStationId < arrivalStationId;
+
+		// 구간 겹침 조건 정의
+		// 예약 구간: [기존출발 ~ 기존도착]
+		// 요청 구간: [검색출발 ~ 검색도착]
+		// 겹침 조건: 기존출발 < 검색도착 AND 기존도착 > 검색출발 (하행 기준)
+		//           기존출발 > 검색도착 AND 기존도착 < 검색출발 (상행 기준)
+		BooleanExpression overlapCondition = isDownward
+			? sr.departureStation.id.lt(arrivalStationId)
+			.and(sr.arrivalStation.id.gt(departureStationId)) // 하행
+			: sr.departureStation.id.gt(arrivalStationId)
+			.and(sr.arrivalStation.id.lt(departureStationId)); // 상행
+
 		// 1. 해당 trainScheduleId의 객차(trainCar) 조회
 		List<TrainCarProjection> carProjections = queryFactory
 			.select(new QTrainCarProjection(
@@ -65,9 +84,7 @@ public class TrainCarQueryRepositoryCustomImpl implements TrainCarQueryRepositor
 				sr.trainSchedule.id.eq(trainScheduleId), // trainSchedule 직접 참조
 				sr.seatStatus.in(SeatStatus.RESERVED, SeatStatus.LOCKED),
 				sr.isStanding.isFalse(),
-				// 구간 겹침 조건
-				sr.departureStation.id.lt(arrivalStationId)
-					.and(sr.arrivalStation.id.gt(departureStationId))
+				overlapCondition  // 구간 겹침 조건
 			)
 			.groupBy(tc.id)
 			.fetch()


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #138

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 상행 구간에서 좌석 예약/조회 오류 수정
- departureStationId 와 arrivalStationId 크기를 비교하여 상/하행 여부 판단
- 구간 겹침 조건을 방향에 따라 분기하여 적용 (lt/gt ↔ gt/lt)
- SeatReservationQueryRepository, TrainCarQueryRepository 내 쿼리 수정


## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
하행(서울 → 부산)에서는 기존 조건을 유지하고 상행(부산 → 서울)에서는 반대로 조건 처리하도록 수정했습니다.

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.