### PR TITLE
[CHORE] Spring Pod 최대 메모리 제한 1GiB로 상향 조정

### DIFF
--- a/k8s/depl_svc.yml
+++ b/k8s/depl_svc.yml
@@ -24,11 +24,11 @@ spec:
             # 컨테이너가 사용할수 있는 리소스의 최대치
             limits:
               cpu: "1"
-              memory: "500Mi"
+              memory: "1Gi"
             # 컨테이너가 시작될떄 보장받아야 하는 최소 자원
             requests:
               cpu: "0.5"
-              memory: "250Mi"
+              memory: "512Mi"
           env:
             # name값과 yml의 ${변수} 의 변수명과 일치해야함
             - name: DB_URL


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #156

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- limits.memory를 기존 500Mi → 1Gi로 상향 조정
- requests.memory도 250Mi → 512Mi로 변경하여 안정성 확보

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
원활한 성능 테스트를 위해 최대 메모리 limit을 상향 조정 하였습니다. 추가로 최소 memory request도 같이 상향 조정하였습니다.
현재는 노드 그룹에서 원하는 노드 크기, 최소 노드 크기를 0으로 변경하여 모든 Pod가 Pending으로 내려간 상태입니다.
따라서 백엔드 관련 도메인은 현재 접속하실 수 없으며 월요일에 다시 띄울 예정입니다.
<img width="500" height="438" alt="image" src="https://github.com/user-attachments/assets/07230192-0387-4051-96f7-cc65ccadd5ba" />

<img width="1407" height="357" alt="image" src="https://github.com/user-attachments/assets/99debca3-fdae-4767-96c9-9bd84046f67f" />


## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.