### PR TITLE
[REFACTOR] @OneToMany 제거

### DIFF
--- a/src/main/java/com/sudo/railo/train/application/TrainService.java
+++ b/src/main/java/com/sudo/railo/train/application/TrainService.java
@@ -29,7 +29,7 @@ public class TrainService {
 
 	@Transactional(readOnly = true)
 	public Map<Integer, Train> getTrainMap() {
-		return trainRepository.findAllWithCars().stream()
+		return trainRepository.findAll().stream()
 			.collect(Collectors.toMap(Train::getTrainNumber, Function.identity()));
 	}
 
@@ -38,7 +38,7 @@ public class TrainService {
 	 */
 	@Transactional
 	public Map<Integer, Train> findOrCreateTrains(List<TrainData> trainData) {
-		Map<Integer, Train> trainMap = findExistingTrains();
+		Map<Integer, Train> trainMap = getTrainMap();
 
 		// 열차 생성
 		List<Train> trains = trainData.stream()
@@ -60,14 +60,6 @@ public class TrainService {
 
 		// 열차 ID가 없어서 다시 조회
 		return getTrainMap();
-	}
-
-	/**
-	 * 이미 존재하는 열차 조회
-	 */
-	private Map<Integer, Train> findExistingTrains() {
-		return trainRepository.findAllWithCars().stream()
-			.collect(Collectors.toMap(Train::getTrainNumber, Function.identity()));
 	}
 
 	/**

--- a/src/main/java/com/sudo/railo/train/domain/Train.java
+++ b/src/main/java/com/sudo/railo/train/domain/Train.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.Comment;
 import com.sudo.railo.train.domain.type.CarType;
 import com.sudo.railo.train.domain.type.TrainType;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,7 +18,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,9 +41,6 @@ public class Train {
 	private String trainName;
 
 	private int totalCars;
-
-	@OneToMany(mappedBy = "train", cascade = CascadeType.ALL)
-	private final List<TrainCar> trainCars = new ArrayList<>();
 
 	/* 생성 메서드 */
 
@@ -85,36 +80,5 @@ public class Train {
 			trainCar.setTrain(this);
 		}
 		return trainCars;
-	}
-
-	/* 조회 로직 */
-
-	/**
-	 * 좌석 타입별 총 좌석 수 계산
-	 */
-	public int getTotalSeatsByType(CarType carType) {
-		return trainCars.stream()
-			.filter(car -> car.getCarType() == carType)
-			.mapToInt(TrainCar::getTotalSeats)
-			.sum();
-	}
-
-	/**
-	 * 좌석 타입별 칸 목록
-	 */
-	public List<TrainCar> getCarsByType(CarType carType) {
-		return trainCars.stream()
-			.filter(car -> car.getCarType() == carType)
-			.toList();
-	}
-
-	/**
-	 * 지원하는 좌석 타입
-	 */
-	public List<CarType> getSupportedCarTypes() {
-		return trainCars.stream()
-			.map(TrainCar::getCarType)
-			.distinct()
-			.toList();
 	}
 }

--- a/src/main/java/com/sudo/railo/train/domain/TrainCar.java
+++ b/src/main/java/com/sudo/railo/train/domain/TrainCar.java
@@ -9,7 +9,6 @@ import org.hibernate.annotations.Comment;
 
 import com.sudo.railo.train.domain.type.CarType;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -20,7 +19,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,7 +38,7 @@ public class TrainCar {
 
 	@Enumerated(EnumType.STRING)
 	private CarType carType;
-	
+
 	private int seatRowCount;
 
 	private int totalSeats;
@@ -52,9 +50,6 @@ public class TrainCar {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "train_id")
 	private Train train;
-
-	@OneToMany(mappedBy = "trainCar", cascade = CascadeType.ALL)
-	private final List<Seat> seats = new ArrayList<>();
 
 	/* 생성 메서드 */
 

--- a/src/main/java/com/sudo/railo/train/domain/TrainSchedule.java
+++ b/src/main/java/com/sudo/railo/train/domain/TrainSchedule.java
@@ -1,21 +1,11 @@
 package com.sudo.railo.train.domain;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import com.sudo.railo.train.domain.status.OperationStatus;
-import com.sudo.railo.train.domain.type.CarType;
-import com.sudo.railo.train.domain.type.SeatAvailabilityStatus;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -26,9 +16,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.MapKeyEnumerated;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -86,18 +73,6 @@ public class TrainSchedule {
 	@JoinColumn(name = "arrival_station_id")
 	private Station arrivalStation;
 
-	// 좌석 타입별 잔여 좌석 수 (Map 형태로 저장)
-	@ElementCollection
-	@CollectionTable(name = "schedule_available_seats",
-		joinColumns = @JoinColumn(name = "train_schedule_id"))
-	@MapKeyColumn(name = "car_type")
-	@MapKeyEnumerated(EnumType.STRING)
-	@Column(name = "available_seats")
-	private Map<CarType, Integer> availableSeatsMap = new HashMap<>();
-
-	@OneToMany(mappedBy = "trainSchedule", cascade = CascadeType.ALL)
-	private final List<ScheduleStop> scheduleStops = new ArrayList<>();
-
 	/* 생성 메서드 */
 
 	/**
@@ -123,9 +98,6 @@ public class TrainSchedule {
 		this.train = train;
 		this.departureStation = departureStation;
 		this.arrivalStation = arrivalStation;
-
-		// 초기 좌석 수 설정
-		initializeAvailableSeats();
 	}
 
 	/**
@@ -142,14 +114,6 @@ public class TrainSchedule {
 			template.getDepartureStation(),
 			template.getArrivalStation()
 		);
-	}
-
-	/** 초기 좌석 수 설정 */
-	private void initializeAvailableSeats() {
-		for (CarType carType : train.getSupportedCarTypes()) {
-			int totalSeats = train.getTotalSeatsByType(carType);
-			availableSeatsMap.put(carType, totalSeats);
-		}
 	}
 
 	/* 비즈니스 메서드 */
@@ -176,74 +140,5 @@ public class TrainSchedule {
 	public void recoverDelay() {
 		this.delayMinutes = 0;
 		this.operationStatus = OperationStatus.ACTIVE;
-	}
-
-	/* 조회 로직 */
-
-	// 특정 타입 잔여 좌석 수 조회
-	public int getAvailableSeats(CarType carType) {
-		return availableSeatsMap.getOrDefault(carType, 0);
-	}
-
-	// 특정 타입 총 좌석 수 조회
-	public int getTotalSeats(CarType carType) {
-		return train.getTotalSeatsByType(carType);
-	}
-
-	// 예약 가능 여부 확인
-	public boolean canReserveSeats(CarType carType, int seatCount) {
-		if (!isOperational())
-			return false;
-		if (!train.getSupportedCarTypes().contains(carType))
-			return false;
-		return getAvailableSeats(carType) >= seatCount;
-	}
-
-	// 좌석 가용성 상태 확인
-	public SeatAvailabilityStatus getSeatAvailabilityStatus(CarType carType) {
-		int available = getAvailableSeats(carType);
-
-		if (available == 0) {
-			return SeatAvailabilityStatus.SOLD_OUT;
-		} else if (available <= 5) {
-			return SeatAvailabilityStatus.FEW_REMAINING;
-		} else if (available <= 10) {
-			return SeatAvailabilityStatus.LIMITED;
-		} else {
-			return SeatAvailabilityStatus.AVAILABLE;
-		}
-	}
-
-	// 운행 가능 여부
-	public boolean isOperational() {
-		return operationStatus == OperationStatus.ACTIVE ||
-			operationStatus == OperationStatus.DELAYED;
-	}
-
-	// 소요 시간 계산
-	public Duration getTravelDuration() {
-		return Duration.between(departureTime, arrivalTime);
-	}
-
-	/* 검증 로직 */
-
-	// 좌석 예약 검증
-	private void validateSeatReservation(CarType carType, int seatCount) {
-		if (seatCount <= 0) {
-			throw new IllegalArgumentException("좌석 수는 1 이상이어야 합니다");
-		}
-
-		if (!isOperational()) {
-			throw new IllegalStateException("운행이 중단된 열차입니다");
-		}
-
-		if (!train.getSupportedCarTypes().contains(carType)) {
-			throw new IllegalArgumentException("지원하지 않는 좌석 타입입니다: " + carType);
-		}
-
-		if (getAvailableSeats(carType) < seatCount) {
-			throw new IllegalStateException(
-				"좌석이 부족합니다. 요청: " + seatCount + "석, 잔여: " + getAvailableSeats(carType) + "석");
-		}
 	}
 }

--- a/src/main/java/com/sudo/railo/train/infrastructure/TrainCarQueryRepositoryCustomImpl.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/TrainCarQueryRepositoryCustomImpl.java
@@ -75,7 +75,7 @@ public class TrainCarQueryRepositoryCustomImpl implements TrainCarQueryRepositor
 			))
 			.from(ts)
 			.join(ts.train, t)
-			.join(t.trainCars, tc)
+			.join(tc).on(tc.train.id.eq(t.id))
 			.where(ts.id.eq(trainScheduleId))
 			.orderBy(tc.carNumber.asc())
 			.fetch();

--- a/src/main/java/com/sudo/railo/train/infrastructure/TrainRepository.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/TrainRepository.java
@@ -4,14 +4,10 @@ import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.sudo.railo.train.domain.Train;
 
 public interface TrainRepository extends JpaRepository<Train, Long> {
-
-	@Query("SELECT t FROM Train t JOIN FETCH t.trainCars")
-	List<Train> findAllWithCars();
 
 	List<Train> findByTrainNumberIn(Collection<Integer> trainNumbers);
 }

--- a/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepositoryCustomImpl.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/TrainScheduleRepositoryCustomImpl.java
@@ -82,8 +82,8 @@ public class TrainScheduleRepositoryCustomImpl implements TrainScheduleRepositor
 		JPAQuery<Long> validScheduleSubQuery = queryFactory
 			.select(ts.id)
 			.from(ts)
-			.join(ts.scheduleStops, departureStop)
-			.join(ts.scheduleStops, arrivalStop)
+			.join(departureStop).on(departureStop.trainSchedule.id.eq(ts.id))
+			.join(arrivalStop).on(arrivalStop.trainSchedule.id.eq(ts.id))
 			.where(
 				ts.operationDate.eq(operationDate)
 					.and(ts.operationStatus.eq(OperationStatus.ACTIVE))
@@ -110,9 +110,9 @@ public class TrainScheduleRepositoryCustomImpl implements TrainScheduleRepositor
 				arrivalStation.stationName))
 			.from(ts)
 			.join(ts.train, t)
-			.join(ts.scheduleStops, depStop2)
+			.join(depStop2).on(depStop2.trainSchedule.id.eq(ts.id))
 			.join(depStop2.station, departureStation)
-			.join(ts.scheduleStops, arrStop2)
+			.join(arrStop2).on(arrStop2.trainSchedule.id.eq(ts.id))
 			.join(arrStop2.station, arrivalStation)
 			.where(
 				ts.id.in(validScheduleSubQuery)
@@ -162,7 +162,7 @@ public class TrainScheduleRepositoryCustomImpl implements TrainScheduleRepositor
 			.select(tc.carType, tc.totalSeats.sum())    // 객차타입별 좌석수 합계
 			.from(ts)
 			.join(ts.train, t)                          // 열차 조인
-			.join(t.trainCars, tc)                      // 객차 조인
+			.join(tc).on(tc.train.eq(t))                // 객차 조인
 			.where(ts.id.eq(trainScheduleId))           // 특정 열차 스케줄
 			.groupBy(tc.carType)                        // 객차 타입별 그룹화
 			.fetch();
@@ -188,7 +188,7 @@ public class TrainScheduleRepositoryCustomImpl implements TrainScheduleRepositor
 			.select(tc.totalSeats.sum())
 			.from(ts)
 			.join(ts.train, t)
-			.join(t.trainCars, tc)
+			.join(tc).on(tc.train.eq(t))
 			.where(ts.id.eq(trainScheduleId))
 			.fetchOne();
 


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #172 

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- Train - TrainCar `@OneToMany` 매핑 제거
- TrainCar - Seat `@OneToMany` 매핑 제거
- TrainSchedule - ScheduleStop `@OneToMany` 매핑 제거
- TrainSchedule `availableSeatsMap` 삭제

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
- 복잡한 테스트 데이터 설정 문제 해결과 테스트 용이성 확보를 위해 `@OneToMany`를 사용하지 않도록 수정했습니다.
- 사용하고 있지 않은 `availableSeatsMap` 필드를 삭제했습니다.
- `TrainScheduleTemplate`에 `@OneToMany`가 남아있는데, `ScheduleStop`을 반복적으로 생성하는 것보다 노선 테이블을 두는 게 좋을 것 같아서 이후 이슈에서 수정해보겠습니다.

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.