### PR TITLE
[BUG] 로그아웃 시 Redis Duration 타입 직렬화/역직렬화 오류

### DIFF
--- a/src/main/java/com/sudo/railo/global/config/RedisConfig.java
+++ b/src/main/java/com/sudo/railo/global/config/RedisConfig.java
@@ -54,19 +54,15 @@ public class RedisConfig {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 
-		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper());
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 		redisTemplate.setDefaultSerializer(serializer);
 		redisTemplate.setValueSerializer(serializer);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 
 		return redisTemplate;
-	}
-
-	@Bean
-	protected ObjectMapper redisObjectMapper() {
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.registerModule(new JavaTimeModule());
-		return objectMapper;
 	}
 
 }

--- a/src/main/java/com/sudo/railo/global/config/RedisConfig.java
+++ b/src/main/java/com/sudo/railo/global/config/RedisConfig.java
@@ -11,6 +11,9 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -51,12 +54,19 @@ public class RedisConfig {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 
-		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper());
 		redisTemplate.setDefaultSerializer(serializer);
 		redisTemplate.setValueSerializer(serializer);
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 
 		return redisTemplate;
+	}
+
+	@Bean
+	protected ObjectMapper redisObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		return objectMapper;
 	}
 
 }


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #178 

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- RedisConfig에 objectMapper() 설정 추가

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
기존 Redis 관련 파일을 리팩토링하면서 LogoutToken 의 날짜 타입을 Duration 으로 변경 했었습니다.
그 이후 테스트 시 로그아웃 로직에서 다음과 같은 Redis 관련 직렬화/역직렬화 오류가 생긴 것을 확인하였습니다.
> org.springframework.data.redis.serializer.SerializationException: Could not write JSON: Java 8 date/time type java.time.Duration not supported by default

확인해본 결과 해당 문제는 Java 8 Date/Time API (예: java.time.Duration) 타입을 JSON으로 직렬화(또는 역직렬화)할 때 Jackson이 기본적으로 이를 지원하지 않아서 발생하는 오류로 확인되었습니다.

따라서 이를 해결하기 위해 Jackson 내부적으로 사용되고 있는 ObjectMapper 가 날짜/시간 API를 직렬화 및 역직렬화 할 수 있도록 JavaTImeModule()을 등록 후 GenericJacson2JsonRedisSerializer 에 주입시켜주었습니다.

```java
	@Bean
	public RedisTemplate<String, Object> customObjectRedisTemplate() {
		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
		redisTemplate.setConnectionFactory(redisConnectionFactory());

		ObjectMapper objectMapper = new ObjectMapper();
		objectMapper.registerModule(new JavaTimeModule());

		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
		redisTemplate.setDefaultSerializer(serializer);
		redisTemplate.setValueSerializer(serializer);
		redisTemplate.setKeySerializer(new StringRedisSerializer());

		return redisTemplate;
	}
}
```

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
해당 코드 추가 후 문제 없이 로그아웃 로직이 동작하는 것을 확인했습니다 😄 

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.