### PR TITLE
[REFACTOR] Http only 적용

### DIFF
--- a/src/main/java/com/sudo/railo/auth/application/AuthService.java
+++ b/src/main/java/com/sudo/railo/auth/application/AuthService.java
@@ -11,17 +11,17 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.sudo.railo.auth.application.dto.request.LoginRequest;
+import com.sudo.railo.auth.application.dto.request.SignUpRequest;
+import com.sudo.railo.auth.application.dto.response.ReissueTokenResponse;
+import com.sudo.railo.auth.application.dto.response.SignUpResponse;
+import com.sudo.railo.auth.application.dto.response.TokenResponse;
 import com.sudo.railo.auth.security.TokenError;
 import com.sudo.railo.auth.security.jwt.TokenProvider;
 import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.global.redis.AuthRedisRepository;
 import com.sudo.railo.global.redis.LogoutToken;
 import com.sudo.railo.member.application.MemberNoGenerator;
-import com.sudo.railo.auth.application.dto.request.MemberNoLoginRequest;
-import com.sudo.railo.auth.application.dto.request.SignUpRequest;
-import com.sudo.railo.auth.application.dto.response.ReissueTokenResponse;
-import com.sudo.railo.auth.application.dto.response.SignUpResponse;
-import com.sudo.railo.auth.application.dto.response.TokenResponse;
 import com.sudo.railo.member.domain.Member;
 import com.sudo.railo.member.domain.MemberDetail;
 import com.sudo.railo.member.domain.Membership;
@@ -63,7 +63,7 @@ public class AuthService {
 	}
 
 	@Transactional
-	public TokenResponse memberNoLogin(MemberNoLoginRequest request) {
+	public TokenResponse login(LoginRequest request) {
 
 		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
 			request.memberNo(), request.password());

--- a/src/main/java/com/sudo/railo/auth/application/AuthService.java
+++ b/src/main/java/com/sudo/railo/auth/application/AuthService.java
@@ -92,7 +92,9 @@ public class AuthService {
 	}
 
 	@Transactional
-	public ReissueTokenResponse reissueAccessToken(String refreshToken, String memberNo) {
+	public ReissueTokenResponse reissueAccessToken(String refreshToken) {
+
+		String memberNo = tokenProvider.getMemberNo(refreshToken);
 
 		String restoredRefreshToken = authRedisRepository.getRefreshToken(memberNo);
 

--- a/src/main/java/com/sudo/railo/auth/application/AuthService.java
+++ b/src/main/java/com/sudo/railo/auth/application/AuthService.java
@@ -16,7 +16,7 @@ import com.sudo.railo.auth.application.dto.request.SignUpRequest;
 import com.sudo.railo.auth.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.auth.application.dto.response.SignUpResponse;
 import com.sudo.railo.auth.application.dto.response.TokenResponse;
-import com.sudo.railo.auth.security.TokenError;
+import com.sudo.railo.auth.exception.TokenError;
 import com.sudo.railo.auth.security.jwt.TokenProvider;
 import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.global.redis.AuthRedisRepository;

--- a/src/main/java/com/sudo/railo/auth/application/dto/request/LoginRequest.java
+++ b/src/main/java/com/sudo/railo/auth/application/dto/request/LoginRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "회원번호 기반 로그인 요청 DTO")
-public record MemberNoLoginRequest(
+public record LoginRequest(
 
 	@Schema(description = "회원의 고유 번호", example = "202506260001")
 	@NotBlank(message = "회원번호는 필수입니다.")

--- a/src/main/java/com/sudo/railo/auth/application/dto/response/LoginResponse.java
+++ b/src/main/java/com/sudo/railo/auth/application/dto/response/LoginResponse.java
@@ -1,0 +1,17 @@
+package com.sudo.railo.auth.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 응답 DTO")
+public record LoginResponse(
+
+	@Schema(description = "토큰의 타입 (예: Bearer)", example = "Bearer")
+	String grantType,
+
+	@Schema(description = "발급된 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	String accessToken,
+
+	@Schema(description = "액세스 토큰의 만료 시간", example = "1750508812329")
+	Long accessTokenExpiresIn
+) {
+}

--- a/src/main/java/com/sudo/railo/auth/docs/AuthControllerDocs.java
+++ b/src/main/java/com/sudo/railo/auth/docs/AuthControllerDocs.java
@@ -1,12 +1,12 @@
 package com.sudo.railo.auth.docs;
 
-import com.sudo.railo.global.exception.error.ErrorResponse;
-import com.sudo.railo.global.success.SuccessResponse;
-import com.sudo.railo.auth.application.dto.request.MemberNoLoginRequest;
+import com.sudo.railo.auth.application.dto.request.LoginRequest;
 import com.sudo.railo.auth.application.dto.request.SignUpRequest;
+import com.sudo.railo.auth.application.dto.response.LoginResponse;
 import com.sudo.railo.auth.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.auth.application.dto.response.SignUpResponse;
-import com.sudo.railo.auth.application.dto.response.TokenResponse;
+import com.sudo.railo.global.exception.error.ErrorResponse;
+import com.sudo.railo.global.success.SuccessResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Tag(name = "Authentication", description = "🔐 인증 API - 회원 로그인, 회원가입, 토큰 관리 API")
 public interface AuthControllerDocs {
@@ -33,7 +34,7 @@ public interface AuthControllerDocs {
 		@ApiResponse(responseCode = "200", description = "로그인에 성공하였습니다."),
 		@ApiResponse(responseCode = "401", description = "비밀번호가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
-	SuccessResponse<TokenResponse> memberNoLogin(MemberNoLoginRequest request);
+	SuccessResponse<LoginResponse> login(LoginRequest request, HttpServletResponse response);
 
 	@Operation(method = "POST", summary = "로그아웃", description = "로그인 되어있는 회원을 로그아웃 처리합니다.",
 		security = {@SecurityRequirement(name = "bearerAuth")})

--- a/src/main/java/com/sudo/railo/auth/docs/AuthControllerDocs.java
+++ b/src/main/java/com/sudo/railo/auth/docs/AuthControllerDocs.java
@@ -50,6 +50,6 @@ public interface AuthControllerDocs {
 		@ApiResponse(responseCode = "200", description = "accessToken 이 성공적으로 재발급되었습니다."),
 		@ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
-	SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request, String memberNo);
+	SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request);
 
 }

--- a/src/main/java/com/sudo/railo/auth/docs/AuthControllerDocs.java
+++ b/src/main/java/com/sudo/railo/auth/docs/AuthControllerDocs.java
@@ -50,6 +50,6 @@ public interface AuthControllerDocs {
 		@ApiResponse(responseCode = "200", description = "accessToken 이 성공적으로 재발급되었습니다."),
 		@ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
-	SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request);
+	SuccessResponse<ReissueTokenResponse> reissue(String refreshToken);
 
 }

--- a/src/main/java/com/sudo/railo/auth/exception/TokenError.java
+++ b/src/main/java/com/sudo/railo/auth/exception/TokenError.java
@@ -1,4 +1,4 @@
-package com.sudo.railo.auth.security;
+package com.sudo.railo.auth.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
@@ -6,18 +6,21 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.sudo.railo.auth.security.jwt.TokenExtractor;
-import com.sudo.railo.global.success.SuccessResponse;
 import com.sudo.railo.auth.application.AuthService;
-import com.sudo.railo.auth.application.dto.request.MemberNoLoginRequest;
+import com.sudo.railo.auth.application.dto.request.LoginRequest;
 import com.sudo.railo.auth.application.dto.request.SignUpRequest;
+import com.sudo.railo.auth.application.dto.response.LoginResponse;
 import com.sudo.railo.auth.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.auth.application.dto.response.SignUpResponse;
 import com.sudo.railo.auth.application.dto.response.TokenResponse;
 import com.sudo.railo.auth.docs.AuthControllerDocs;
+import com.sudo.railo.auth.security.jwt.TokenExtractor;
 import com.sudo.railo.auth.success.AuthSuccess;
+import com.sudo.railo.global.success.SuccessResponse;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,11 +43,22 @@ public class AuthController implements AuthControllerDocs {
 	}
 
 	@PostMapping("/login")
-	public SuccessResponse<TokenResponse> memberNoLogin(@RequestBody @Valid MemberNoLoginRequest request) {
+	public SuccessResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request,
+		HttpServletResponse response) {
 
-		TokenResponse tokenResponse = authService.memberNoLogin(request);
+		TokenResponse tokenResponse = authService.login(request);
+		LoginResponse loginResponse = new LoginResponse(tokenResponse.grantType(), tokenResponse.accessToken(),
+			tokenResponse.accessTokenExpiresIn());
 
-		return SuccessResponse.of(AuthSuccess.MEMBER_NO_LOGIN_SUCCESS, tokenResponse);
+		Cookie cookie = new Cookie("refreshToken", tokenResponse.refreshToken());
+		cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
+		cookie.setSecure(true); // secure cookie 적용
+		cookie.setHttpOnly(true); // JavaScript 에서 접근 금지
+		cookie.setPath("/"); // 모든 경로에서 쿠키 전송 가능
+
+		response.addCookie(cookie); // 쿠키 전달
+
+		return SuccessResponse.of(AuthSuccess.MEMBER_NO_LOGIN_SUCCESS, loginResponse);
 	}
 
 	@PostMapping("/logout")

--- a/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
@@ -58,7 +58,7 @@ public class AuthController implements AuthControllerDocs {
 		cookie.setHttpOnly(true); // JavaScript 에서 접근 금지
 		cookie.setPath("/"); // 모든 경로에서 쿠키 전송 가능
 
-		response.addCookie(cookie); // 쿠키 전달
+		response.addCookie(cookie);
 
 		return SuccessResponse.of(AuthSuccess.MEMBER_NO_LOGIN_SUCCESS, loginResponse);
 	}
@@ -75,10 +75,9 @@ public class AuthController implements AuthControllerDocs {
 	}
 
 	@PostMapping("/reissue")
-	public SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request,
-		@AuthenticationPrincipal(expression = "username") String memberNo) {
+	public SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request) {
 
-		// refreshToken Cookie 에서 추출
+		// refreshToken 을 Cookie 에서 추출
 		String refreshToken = null;
 		if (request.getCookies() != null) {
 			for (Cookie cookie : request.getCookies()) {
@@ -93,7 +92,9 @@ public class AuthController implements AuthControllerDocs {
 			throw new BusinessException(TokenError.INVALID_REFRESH_TOKEN);
 		}
 
-		ReissueTokenResponse tokenResponse = authService.reissueAccessToken(refreshToken, memberNo);
+		log.info("refreshToken: {}", refreshToken);
+
+		ReissueTokenResponse tokenResponse = authService.reissueAccessToken(refreshToken);
 
 		return SuccessResponse.of(AuthSuccess.REISSUE_TOKEN_SUCCESS, tokenResponse);
 	}

--- a/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
@@ -14,8 +14,10 @@ import com.sudo.railo.auth.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.auth.application.dto.response.SignUpResponse;
 import com.sudo.railo.auth.application.dto.response.TokenResponse;
 import com.sudo.railo.auth.docs.AuthControllerDocs;
+import com.sudo.railo.auth.exception.TokenError;
 import com.sudo.railo.auth.security.jwt.TokenExtractor;
 import com.sudo.railo.auth.success.AuthSuccess;
+import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.global.success.SuccessResponse;
 
 import jakarta.servlet.http.Cookie;
@@ -76,7 +78,20 @@ public class AuthController implements AuthControllerDocs {
 	public SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request,
 		@AuthenticationPrincipal(expression = "username") String memberNo) {
 
-		String refreshToken = tokenExtractor.resolveToken(request);
+		// refreshToken Cookie 에서 추출
+		String refreshToken = null;
+		if (request.getCookies() != null) {
+			for (Cookie cookie : request.getCookies()) {
+				if (cookie.getName().equals("refreshToken")) {
+					refreshToken = cookie.getValue();
+					break;
+				}
+			}
+		}
+
+		if (refreshToken == null || refreshToken.isEmpty()) {
+			throw new BusinessException(TokenError.INVALID_REFRESH_TOKEN);
+		}
 
 		ReissueTokenResponse tokenResponse = authService.reissueAccessToken(refreshToken, memberNo);
 

--- a/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
@@ -35,6 +35,9 @@ public class AuthController implements AuthControllerDocs {
 	private final AuthService authService;
 	private final TokenExtractor tokenExtractor;
 
+	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+	private static final String COOKIE_PATH = "/";
+
 	@PostMapping("/signup")
 	public SuccessResponse<SignUpResponse> signUp(@RequestBody @Valid SignUpRequest request) {
 
@@ -51,15 +54,19 @@ public class AuthController implements AuthControllerDocs {
 		LoginResponse loginResponse = new LoginResponse(tokenResponse.grantType(), tokenResponse.accessToken(),
 			tokenResponse.accessTokenExpiresIn());
 
-		Cookie cookie = new Cookie("refreshToken", tokenResponse.refreshToken());
-		cookie.setMaxAge(7 * 24 * 60 * 60); // 7일
-		cookie.setSecure(true); // secure cookie 적용
-		cookie.setHttpOnly(true); // JavaScript 에서 접근 금지
-		cookie.setPath("/"); // 모든 경로에서 쿠키 전송 가능
+		setRefreshTokenCookie(response, tokenResponse.refreshToken());
+
+		return SuccessResponse.of(AuthSuccess.LOGIN_SUCCESS, loginResponse);
+	}
+
+	private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+		cookie.setMaxAge(7 * 24 * 60 * 6);
+		cookie.setSecure(true); // HTTPS 환경에서만 전송
+		cookie.setHttpOnly(true); // JavaScript 접근 차단
+		cookie.setPath(COOKIE_PATH); // 모든 경로에서 쿠키 전송 가능
 
 		response.addCookie(cookie);
-
-		return SuccessResponse.of(AuthSuccess.MEMBER_NO_LOGIN_SUCCESS, loginResponse);
 	}
 
 	@PostMapping("/logout")

--- a/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
@@ -35,6 +35,7 @@ public class AuthController implements AuthControllerDocs {
 	private final AuthService authService;
 	private final TokenExtractor tokenExtractor;
 
+	private static final int REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60;
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 	private static final String COOKIE_PATH = "/";
 
@@ -61,7 +62,7 @@ public class AuthController implements AuthControllerDocs {
 
 	private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
 		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
-		cookie.setMaxAge(7 * 24 * 60 * 6);
+		cookie.setMaxAge(REFRESH_TOKEN_MAX_AGE);
 		cookie.setSecure(true); // HTTPS 환경에서만 전송
 		cookie.setHttpOnly(true); // JavaScript 접근 차단
 		cookie.setPath(COOKIE_PATH); // 모든 경로에서 쿠키 전송 가능

--- a/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
+++ b/src/main/java/com/sudo/railo/auth/presentation/AuthController.java
@@ -1,6 +1,7 @@
 package com.sudo.railo.auth.presentation;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,9 +26,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -75,24 +74,11 @@ public class AuthController implements AuthControllerDocs {
 	}
 
 	@PostMapping("/reissue")
-	public SuccessResponse<ReissueTokenResponse> reissue(HttpServletRequest request) {
-
-		// refreshToken 을 Cookie 에서 추출
-		String refreshToken = null;
-		if (request.getCookies() != null) {
-			for (Cookie cookie : request.getCookies()) {
-				if (cookie.getName().equals("refreshToken")) {
-					refreshToken = cookie.getValue();
-					break;
-				}
-			}
-		}
+	public SuccessResponse<ReissueTokenResponse> reissue(@CookieValue("refreshToken") String refreshToken) {
 
 		if (refreshToken == null || refreshToken.isEmpty()) {
 			throw new BusinessException(TokenError.INVALID_REFRESH_TOKEN);
 		}
-
-		log.info("refreshToken: {}", refreshToken);
 
 		ReissueTokenResponse tokenResponse = authService.reissueAccessToken(refreshToken);
 

--- a/src/main/java/com/sudo/railo/auth/security/jwt/JwtFilter.java
+++ b/src/main/java/com/sudo/railo/auth/security/jwt/JwtFilter.java
@@ -8,7 +8,7 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.sudo.railo.auth.security.TokenError;
+import com.sudo.railo.auth.exception.TokenError;
 import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.global.redis.AuthRedisRepository;
 

--- a/src/main/java/com/sudo/railo/auth/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/auth/security/jwt/TokenProvider.java
@@ -16,10 +16,10 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import com.sudo.railo.auth.security.TokenError;
-import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.auth.application.dto.response.ReissueTokenResponse;
 import com.sudo.railo.auth.application.dto.response.TokenResponse;
+import com.sudo.railo.auth.exception.TokenError;
+import com.sudo.railo.global.exception.error.BusinessException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/com/sudo/railo/auth/security/jwt/TokenProvider.java
+++ b/src/main/java/com/sudo/railo/auth/security/jwt/TokenProvider.java
@@ -137,11 +137,11 @@ public class TokenProvider {
 	}
 
 	// 토큰에 등록된 클레임의 sub에서 해당 회원 번호 추출
-	public String getMemberNo(String accessToken) {
+	public String getMemberNo(String token) {
 		return Jwts.parserBuilder()
 			.setSigningKey(key)
 			.build()
-			.parseClaimsJws(accessToken)
+			.parseClaimsJws(token)
 			.getBody()
 			.getSubject();
 	}

--- a/src/main/java/com/sudo/railo/auth/success/AuthSuccess.java
+++ b/src/main/java/com/sudo/railo/auth/success/AuthSuccess.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum AuthSuccess implements SuccessCode {
 
 	SIGN_UP_SUCCESS(HttpStatus.CREATED, "회원가입이 성공적으로 완료되었습니다."),
-	MEMBER_NO_LOGIN_SUCCESS(HttpStatus.OK, "회원번호 로그인이 성공적으로 완료되었습니다."),
+	LOGIN_SUCCESS(HttpStatus.OK, "회원번호 로그인이 성공적으로 완료되었습니다."),
 	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다."),
 	REISSUE_TOKEN_SUCCESS(HttpStatus.OK, "AccessToken 이 성공적으로 발급 되었습니다."),
 

--- a/src/main/java/com/sudo/railo/global/config/SecurityConfig.java
+++ b/src/main/java/com/sudo/railo/global/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
 			.cors(cors -> cors.configurationSource(corsConfigurationSource))
 			// HTTP 요청에 대한 접근 권한 설정
 			.authorizeHttpRequests(auth -> {
-				auth.requestMatchers("/", "/auth/signup", "/auth/login").permitAll()
+				auth.requestMatchers("/", "/auth/signup", "/auth/login", "/auth/reissue").permitAll()
 					.requestMatchers(HttpMethod.POST, "/auth/emails/**").permitAll()
 					.requestMatchers(HttpMethod.POST, "/auth/member-no/**", "/auth/password/**").permitAll()
 					.requestMatchers("/api/v1/guest/register", "/api/v1/trains/**").permitAll()

--- a/src/main/java/com/sudo/railo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sudo/railo/global/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
-import com.sudo.railo.auth.security.TokenError;
+import com.sudo.railo.auth.exception.TokenError;
 import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.global.exception.error.ErrorResponse;
 import com.sudo.railo.global.exception.error.GlobalError;


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #168 

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 로그인 시 refreshToken은 `http only` 적용 및 `secure cookie`에 담아 프론트로 전달될 수 있게 수정
   - body에 refreshToken은 제외하고 accessToken만 전달할 수 있도록 수정 
- 토큰 재발급 시 refreshToken을 `cookie`에서 가져올 수 있도록 변경
   - 토큰 재발급은 accessToken의 유효시간이 만료되었을 경우 다시 발급받을 수 있는 로직이기 때문에 SecurityConfig 내 해당 엔드포인트를 `permitAll()`로 허용
   - 따라서 로그인 된 사용자의 memberNo를 가져오는 것이 아니라 내부적으로 refreshToken에서 memberNo를 가져올 수 있도록 수정
- 메서드 이름 `memberNoLogin()` -> `login()` 으로 변경
- `TokenError` 파일 경로를 auth/exception 으로 변경


## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
### Hoppscotch로 로그인 테스트 진행
로그인에 성공하게 되면 body에는 accessToken 관련 정보만 담겨 프론트로 전달하게 됩니다.
<img width="564" height="357" alt="스크린샷 2025-07-23 오후 2 54 46" src="https://github.com/user-attachments/assets/51aaca7a-2edf-408a-8020-c2dd03428752" />
refreshToken은 cookie에 담겨 따로 프론트로 보냅니다.

<br>

### Hoppscotch로 토큰 재발급 테스트 진행
<img width="749" height="174" alt="스크린샷 2025-07-23 오후 6 33 33" src="https://github.com/user-attachments/assets/f2dcb62b-fe8d-4666-bec3-288e295d6789" />

토큰 재발급을 테스트 하실 분들은 헤더에 Cookie 값으로 로그인 시 쿠키에 담아놓은 refreshToken 값을 직접 수동으로 넣어 테스트 해보실 수 있습니다 !

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
Hoppscotch로 테스트 후 문제 없음을 확인했습니다 👍 

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.