### PR TITLE
[FIX] Booking 도메인 리팩토링 후 노선 중간 구간 예매 불가

### DIFF
--- a/src/main/java/com/sudo/railo/booking/domain/SeatReservation.java
+++ b/src/main/java/com/sudo/railo/booking/domain/SeatReservation.java
@@ -37,7 +37,7 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "seat_reservation",
 	indexes = {@Index(name = "idx_seat_reservation_seat", columnList = "train_schedule_id, seat_id")},
-	uniqueConstraints = {@UniqueConstraint(columnNames = {"train_schedule_id", "seat_id"})}
+	uniqueConstraints = {@UniqueConstraint(columnNames = {"train_schedule_id", "seat_id", "reservation_id"})}
 )
 public class SeatReservation extends BaseEntity {
 

--- a/src/main/java/com/sudo/railo/booking/domain/Ticket.java
+++ b/src/main/java/com/sudo/railo/booking/domain/Ticket.java
@@ -39,7 +39,7 @@ public class Ticket extends BaseEntity {
 	@Comment("승차권 ID")
 	private Long id;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "seat_id")
 	@OnDelete(action = OnDeleteAction.SET_NULL)
 	@Comment("좌석 ID")

--- a/src/main/java/com/sudo/railo/train/infrastructure/SeatRepositoryCustomImpl.java
+++ b/src/main/java/com/sudo/railo/train/infrastructure/SeatRepositoryCustomImpl.java
@@ -67,7 +67,9 @@ public class SeatRepositoryCustomImpl implements SeatRepositoryCustom {
 						.then("009")  // 순방향
 						.otherwise("010"), // 역방향
 					// 해당 구간에 예약이 있는지 확인
-					new CaseBuilder().when(seatReservation.id.isNotNull()).then(true).otherwise(false),
+					new CaseBuilder().when(seatReservation.id.isNotNull().and(reservation.id.isNotNull()))
+						.then(true)
+						.otherwise(false),
 					// 4인 동반석 안내 메시지
 					new CaseBuilder().when(seat.seatRow.between(middleRow, middleRow + 1))
 						.then(new CaseBuilder().when(seat.seatRow.eq(middleRow))
@@ -83,8 +85,8 @@ public class SeatRepositoryCustomImpl implements SeatRepositoryCustom {
 				.and(seatReservation.seat.isNotNull())
 			)
 			.leftJoin(reservation)
-			.on(reservation.id.eq(seatReservation.id)
-				.and(overlapCondition)) // 구간 겹침 확인
+			.on(reservation.id.eq(seatReservation.reservation.id)
+				.and(seatReservation.id.isNotNull().and(overlapCondition))) // 구간 겹침 확인
 			.where(seat.trainCar.id.eq(trainCarId))
 			.orderBy(seat.seatRow.asc(), seat.seatColumn.asc())
 			.fetch();


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #181 

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- `SeatReservation` 유니크 제약조건 수정
- `Ticket` 엔티티의 `Seat` 연관관계 수정
- `SeatRepositoryCustomImpl` 쿼리 로직 수정

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
- 잘못된 조인 조건과 null check에 의해 구간 겹침이 제대로 판단되지 않았던것이 원인이었습니다.
- `Ticket` 엔티티의 `Seat` 연관관계 경우, 기존 `OneToOne` 관계였는데 같은 좌석에 대해 시간이 다른 경우가 발생할 수 있어서
  해당 관계를 `ManyToOne`으로 변경하였습니다.
- `SeatRepositoryCustomImpl`, leftjoin 시 잘못된 join 조건을 수정하였고,
  추가적으로 leftjoin 시 일부 필드가 null 값이 될 수 있기때문에 null check 하는 로직을 추가했습니다.
- 기존 스케줄 ID, 좌석 ID를 묶어 유니크 제약조건을 설정했는데, 겹치는 구간에 의해 동일한 경우가 발생할 수 있었습니다.
  `reservation_id` 필드도 포함시켜 해결했습니다.
- 부산 -> 동대구, 동대구 -> 서울 예약 성공 확인했습니다.
- 부산 -> 동대구, 울산 -> 서울 예약 불가능 확인했습니다. (구간 1개역 겹치는 경우. 예약 불가능이 정상)
- 일단 되는것을 확인했습니다만, 다양한 경우로 테스트 부탁드립니다!
- (추가) 기존 스키마를 수정했기때문에 `ddl-auto: update`에 의해 자동으로 수정되지 않습니다.
  `SeatReservation` 테이블과 `Ticket` 테이블을 편하신 방법을 통해 수동으로 날리고 테스트 부탁드립니다.

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.