### PR TITLE
[BUG] 좌석 충돌 예약 발생 오류

### DIFF
--- a/src/main/java/com/sudo/railo/booking/application/ReservationService.java
+++ b/src/main/java/com/sudo/railo/booking/application/ReservationService.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sudo.railo.booking.application.dto.ReservationInfo;
 import com.sudo.railo.booking.application.dto.projection.SeatReservationProjection;
@@ -30,7 +31,6 @@ import com.sudo.railo.booking.infrastructure.reservation.ReservationRepository;
 import com.sudo.railo.booking.infrastructure.reservation.ReservationRepositoryCustom;
 import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.member.domain.Member;
-import com.sudo.railo.member.exception.MemberError;
 import com.sudo.railo.member.infrastructure.MemberRepository;
 import com.sudo.railo.train.domain.ScheduleStop;
 import com.sudo.railo.train.domain.TrainSchedule;
@@ -64,72 +64,17 @@ public class ReservationService {
 	 */
 	@Transactional
 	public Reservation createReservation(ReservationCreateRequest request, UserDetails userDetails) {
-		try {
-			TrainSchedule trainSchedule = trainScheduleRepository.findById(request.trainScheduleId())
-				.orElseThrow(() -> new BusinessException((TrainErrorCode.TRAIN_SCHEDULE_NOT_FOUND)));
+		TrainSchedule trainSchedule = getTrainSchedule(request);
+		Member member = memberRepository.getMember(userDetails.getUsername());
+		ScheduleStop departureStop = getStopStation(trainSchedule, request.departureStationId());
+		ScheduleStop arrivalStop = getStopStation(trainSchedule, request.arrivalStationId());
+		CarType carType = findCarType(request.seatIds());
+		BigDecimal totalFare = getTotalFare(request, carType);
 
-			if (trainSchedule.getOperationStatus() == OperationStatus.CANCELLED) {
-				throw new BusinessException(TrainErrorCode.TRAIN_OPERATION_CANCELLED);
-			}
+		validateTrainOperating(trainSchedule);
 
-			Member member = memberRepository.findByMemberNo(userDetails.getUsername())
-				.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
-
-			ScheduleStop departureStop = scheduleStopRepository.findByTrainScheduleIdAndStationId(
-				trainSchedule.getId(), request.departureStationId()
-			).orElseThrow(() -> new BusinessException(TrainErrorCode.STATION_NOT_FOUND));
-
-			ScheduleStop arrivalStop = scheduleStopRepository.findByTrainScheduleIdAndStationId(
-				trainSchedule.getId(), request.arrivalStationId()
-			).orElseThrow(() -> new BusinessException(TrainErrorCode.STATION_NOT_FOUND));
-
-			// 객차 타입 조회
-			CarType carType = findCarType(request.seatIds());
-
-			// 총 운임 계산
-			BigDecimal totalFare = fareCalculationService.calculateFare(
-				request.departureStationId(),
-				request.arrivalStationId(),
-				request.passengers(),
-				carType
-			);
-
-			List<PassengerSummary> passengerSummary = request.passengers();
-			LocalDateTime now = LocalDateTime.now();
-			Reservation reservation = Reservation.builder()
-				.trainSchedule(trainSchedule)
-				.member(member)
-				.reservationCode(generateReservationCode())
-				.tripType(request.tripType())
-				.totalPassengers(passengerSummary.stream().mapToInt(PassengerSummary::getCount).sum())
-				.passengerSummary(objectMapper.writeValueAsString(passengerSummary))
-				.reservationStatus(ReservationStatus.RESERVED)
-				.expiresAt(now.plusMinutes(bookingConfig.getExpiration().getReservation()))
-				.departureStop(departureStop)
-				.arrivalStop(arrivalStop)
-				.fare(totalFare.intValue())
-				.build();
-			return reservationRepository.save(reservation);
-		} catch (Exception e) {
-			throw new BusinessException(BookingError.RESERVATION_CREATE_FAILED);
-		}
-	}
-
-	/**
-	 * 객차 타입 조회
-	 */
-	private CarType findCarType(List<Long> seatIds) {
-		List<CarType> carTypes = seatRepository.findCarTypes(seatIds);
-
-		// 입석 체크
-		if (seatIds.isEmpty() && carTypes.isEmpty()) {
-			return CarType.STANDARD;
-		}
-
-		if (carTypes.size() != 1) {
-			throw new BusinessException(BookingError.INVALID_CAR_TYPE);
-		}
-		return carTypes.get(0);
+		Reservation reservation = generateReservation(request, trainSchedule, member, departureStop, arrivalStop, totalFare);
+		return reservationRepository.save(reservation);
 	}
 
 	/**
@@ -140,8 +85,7 @@ public class ReservationService {
 	 */
 	@Transactional
 	public ReservationDetail getReservation(String memberNo, Long reservationId) {
-		Member member = memberRepository.findByMemberNo(memberNo)
-			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
+		Member member = memberRepository.getMember(memberNo);
 
 		List<ReservationInfo> reservationInfos = reservationRepositoryCustom.findReservationDetail(
 			member.getId(), List.of(reservationId));
@@ -169,8 +113,7 @@ public class ReservationService {
 	 */
 	@Transactional
 	public List<ReservationDetail> getReservations(String memberNo) {
-		Member member = memberRepository.findByMemberNo(memberNo)
-			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
+		Member member = memberRepository.getMember(memberNo);
 
 		// 예약 조회
 		List<ReservationInfo> reservationInfos = reservationRepositoryCustom.findReservationDetail(member.getId());
@@ -278,6 +221,48 @@ public class ReservationService {
 		return dateTimeStr + randomStr;
 	}
 
+	private ScheduleStop getStopStation(TrainSchedule trainSchedule, Long request) {
+		return scheduleStopRepository.findByTrainScheduleIdAndStationId(trainSchedule.getId(), request)
+			.orElseThrow(() -> new BusinessException(TrainErrorCode.STATION_NOT_FOUND));
+	}
+
+	private TrainSchedule getTrainSchedule(ReservationCreateRequest request) {
+		return trainScheduleRepository.findById(request.trainScheduleId())
+			.orElseThrow(() -> new BusinessException(TrainErrorCode.TRAIN_SCHEDULE_NOT_FOUND));
+	}
+
+	private BigDecimal getTotalFare(ReservationCreateRequest request, CarType carType) {
+		return fareCalculationService.calculateFare(
+			request.departureStationId(),
+			request.arrivalStationId(),
+			request.passengers(),
+			carType
+		);
+	}
+
+	/**
+	 * 객차 타입 조회
+	 */
+	private CarType findCarType(List<Long> seatIds) {
+		List<CarType> carTypes = seatRepository.findCarTypes(seatIds);
+
+		// 입석 체크
+		if (seatIds.isEmpty() && carTypes.isEmpty()) {
+			return CarType.STANDARD;
+		}
+
+		if (carTypes.size() != 1) {
+			throw new BusinessException(BookingError.INVALID_CAR_TYPE);
+		}
+		return carTypes.get(0);
+	}
+
+	private static void validateTrainOperating(TrainSchedule trainSchedule) {
+		if (trainSchedule.getOperationStatus() == OperationStatus.CANCELLED) {
+			throw new BusinessException(TrainErrorCode.TRAIN_OPERATION_CANCELLED);
+		}
+	}
+
 	public List<ReservationDetail> convertToReservationDetail(List<ReservationInfo> reservationInfos) {
 		return reservationInfos.stream()
 			.map(this::convertToReservationDetail)
@@ -311,5 +296,36 @@ public class ReservationService {
 				p.getSeatNumber()
 			))
 			.toList();
+	}
+
+	private Reservation generateReservation(
+		ReservationCreateRequest request,
+		TrainSchedule trainSchedule,
+		Member member,
+		ScheduleStop departureStop,
+		ScheduleStop arrivalStop,
+		BigDecimal totalFare
+	) {
+		return Reservation.builder()
+			.trainSchedule(trainSchedule)
+			.member(member)
+			.reservationCode(generateReservationCode())
+			.tripType(request.tripType())
+			.totalPassengers(request.passengers().stream().mapToInt(PassengerSummary::getCount).sum())
+			.passengerSummary(convertPassengersToJson(request))
+			.reservationStatus(ReservationStatus.RESERVED)
+			.expiresAt(LocalDateTime.now().plusMinutes(bookingConfig.getExpiration().getReservation()))
+			.fare(totalFare.intValue())
+			.departureStop(departureStop)
+			.arrivalStop(arrivalStop)
+			.build();
+	}
+
+	private String convertPassengersToJson(ReservationCreateRequest request) {
+		try {
+			return objectMapper.writeValueAsString(request.passengers());
+		} catch (JsonProcessingException e) {
+			throw new BusinessException(BookingError.RESERVATION_CREATE_FAILED);
+		}
 	}
 }

--- a/src/main/java/com/sudo/railo/booking/application/SeatReservationService.java
+++ b/src/main/java/com/sudo/railo/booking/application/SeatReservationService.java
@@ -10,7 +10,8 @@ import com.sudo.railo.booking.exception.BookingError;
 import com.sudo.railo.booking.infrastructure.SeatReservationRepository;
 import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.train.domain.Seat;
-import com.sudo.railo.train.infrastructure.SeatRepository;
+
+import java.util.List;
 
 import jakarta.persistence.OptimisticLockException;
 import jakarta.transaction.Transactional;
@@ -20,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SeatReservationService {
 
-	private final SeatRepository seatRepository;
 	private final SeatReservationRepository seatReservationRepository;
 
 	/***
@@ -32,6 +32,16 @@ public class SeatReservationService {
 	@Transactional
 	public SeatReservation reserveNewSeat(Reservation reservation, Seat seat, PassengerType passengerType) {
 		try {
+			Long trainScheduleId = reservation.getTrainSchedule().getId();
+			Long seatId = seat.getId();
+
+			// 비관적 락으로 해당 좌석의 모든 예약을 조회 (다른 트랜잭션의 접근 차단)
+			List<SeatReservation> existingReservations = seatReservationRepository
+				.findByTrainScheduleAndSeatWithLock(trainScheduleId, seatId);
+
+			// 락이 걸린 상태에서 충돌 검증 (원자성 보장)
+			validateConflictWithExistingReservations(reservation, existingReservations);
+
 			SeatReservation seatReservation = SeatReservation.builder()
 				.trainSchedule(reservation.getTrainSchedule())
 				.seat(seat)
@@ -42,9 +52,25 @@ public class SeatReservationService {
 		} catch (OptimisticLockException | DataIntegrityViolationException e) {
 			// 동시성 문제 및 유니크 제약 위반 발생
 			throw new BusinessException(BookingError.SEAT_ALREADY_RESERVED);
-		} catch (Exception e) {
-			// 알 수 없는 모든 경우는 실패 처리
-			throw new BusinessException(BookingError.SEAT_RESERVATION_FAILED);
 		}
+	}
+
+	/**
+	 * 기존 예약들과 충돌 검증 (락이 걸린 상태에서 수행)
+	 */
+	private void validateConflictWithExistingReservations(
+		Reservation newReservation,
+		List<SeatReservation> existingReservations
+	) {
+		int newDepartureOrder = newReservation.getDepartureStop().getStopOrder();
+		int newArrivalOrder = newReservation.getArrivalStop().getStopOrder();
+
+		existingReservations.forEach(existingReservation -> {
+			int existingDepartureOrder = existingReservation.getReservation().getDepartureStop().getStopOrder();
+			int existingArrivalOrder = existingReservation.getReservation().getArrivalStop().getStopOrder();
+			if (existingDepartureOrder < newArrivalOrder && existingArrivalOrder > newDepartureOrder) {
+				throw new BusinessException(BookingError.SEAT_ALREADY_RESERVED);
+			}
+		});
 	}
 }

--- a/src/main/java/com/sudo/railo/booking/domain/SeatReservation.java
+++ b/src/main/java/com/sudo/railo/booking/domain/SeatReservation.java
@@ -22,7 +22,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -67,10 +66,6 @@ public class SeatReservation extends BaseEntity {
 	@Column(name = "passenger_type", nullable = false)
 	@Comment("승객 유형")
 	private PassengerType passengerType;
-
-	@Version
-	@Comment("테이블 버전")
-	private Long version;
 
 	public boolean isStanding() {
 		return seat == null;

--- a/src/main/java/com/sudo/railo/booking/infrastructure/SeatReservationRepository.java
+++ b/src/main/java/com/sudo/railo/booking/infrastructure/SeatReservationRepository.java
@@ -1,18 +1,26 @@
 package com.sudo.railo.booking.infrastructure;
 
-import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import com.sudo.railo.booking.domain.SeatReservation;
+
+import jakarta.persistence.LockModeType;
 
 public interface SeatReservationRepository extends JpaRepository<SeatReservation, Long> {
 
 	/***
 	 * 스케줄 ID와 좌석 ID로 좌석 예약 상태를 조회하는 메서드
+	 * 비관적 락을 사용하여 해당 열차 스케줄과 좌석의 모든 예약을 조회
+	 * 동시성 제어를 위해 SeatReservation에 배타적 락을 걸어 다른 트랜잭션의 접근을 차단
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param seatId 좌석 ID
 	 * @return SeatReservation 엔티티
 	 */
-	Optional<SeatReservation> findByTrainScheduleIdAndSeatId(Long trainScheduleId, Long seatId);
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT sr FROM SeatReservation sr WHERE sr.trainSchedule.id = :trainScheduleId AND sr.seat.id = :seatId")
+	List<SeatReservation> findByTrainScheduleAndSeatWithLock(Long trainScheduleId, Long seatId);
 }

--- a/src/main/java/com/sudo/railo/member/infrastructure/MemberRepositoryCustom.java
+++ b/src/main/java/com/sudo/railo/member/infrastructure/MemberRepositoryCustom.java
@@ -2,10 +2,17 @@ package com.sudo.railo.member.infrastructure;
 
 import java.util.Optional;
 
+import com.sudo.railo.global.exception.error.BusinessException;
 import com.sudo.railo.member.domain.Member;
+import com.sudo.railo.member.exception.MemberError;
 
 public interface MemberRepositoryCustom {
 	Optional<Member> findByMemberNo(String memberNo);
 
 	Optional<Member> findMemberByNameAndPhoneNumber(String name, String phoneNumber);
+
+	default Member getMember(String memberNo) {
+		return findByMemberNo(memberNo)
+			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
+	}
 }


### PR DESCRIPTION
## 관련 Issue (필수)
- close #186 

## 주요 변경 사항 (필수)
- ReservationService 리팩토링
- 겹치는 구간 중복 예약 문제 해결
- 동시성 문제 해결을 위한 비관적 락 도입

## 리뷰어 참고 사항
### ReservationService 리팩토링
전체적으로 ReservationService를 리팩토링했습니다. 주요 변경 사항은 다음과 같습니다
- try-catch 문 대신 Unchecked Exception (RuntimeException)을 사용하여 예외 처리
- 메서드 분리를 통해 책임을 명확히 하고 가독성을 개선
- private 메서드의 순서를 재정렬하여 구조를 정리

### 겹치는 구간 중복 예약 문제 해결
기존 로직에서는 stationId를 기준으로 판별하기 때문에 구간 겹침 판단에 오류가 있었습니다. 따라서 stop_order 기반인 열차 스케줄의 정차역 순서로 구간 겹침을 판단하도록 로직을 수정했습니다. (참고 #188)

### 동시성 문제 해결을 위한 비관적 락 도입
기존 낙관적 락 방식에서는 서로 다른 예약 엔티티가 동시에 생성되는 경우, 겹치는 구간에 대해 중복 예약이 허용되는 문제가 있었습니다. 
열차 좌석은 구조상 구간이 다를 경우 하나의 좌석에 여러 예약이 가능합니다.
예시: 
- A역 → C역 예약 (정차 순서: 1 → 3)
- B역 → D역 예약 (정차 순서: 2 → 4)
- 예약 트랜잭션 흐름: 예약(Reservation) 생성 → 예약_좌석(SeatReservation) 생성
- B-C 구간이 겹치므로 하나는 실패해야 하지만, 서로 다른 새로운 SeatReservation 엔티티가 동시에 생성되므로 `@Version`이 작동하지 않아 둘 다 성공하는 문제가 있었습니다.


따라서 비관적 락을 도입하여 아래와 같이 문제를 해결하였습니다.
 1. 좌석별 예약 조회 시점에 PESSIMISTIC_WRITE 락을 적용
 2. 락이 걸린 상태에서 기존 예약들과의 구간 겹침을 검증
 3. 조회 → 검증 → 생성 과정을 원자적으로 처리하여 동시성 문제 방지

## 추가 정보
400명의 사용자가 하나의 열차 스케줄에 대해 좌석을 랜덤한 구간으로 동시에 예약하는 부하 테스트를 수행했습니다.
이 테스트를 통해 좌석 중복 예약 및 동시성 문제로 인한 데이터 불일치가 발생하지 않음을 확인했습니다.
```sql
SELECT
    COUNT(DISTINCT sr1.seat_id) as conflicted_seats
FROM seat_reservation sr1
         JOIN reservation res1 ON sr1.reservation_id = res1.reservation_id
         JOIN schedule_stop dep1 ON res1.departure_stop_id = dep1.schedule_stop_id
         JOIN schedule_stop arr1 ON res1.arrival_stop_id = arr1.schedule_stop_id
         JOIN seat_reservation sr2 ON sr1.seat_id = sr2.seat_id AND sr1.reservation_id != sr2.reservation_id
         JOIN reservation res2 ON sr2.reservation_id = res2.reservation_id
         JOIN schedule_stop dep2 ON res2.departure_stop_id = dep2.schedule_stop_id
         JOIN schedule_stop arr2 ON res2.arrival_stop_id = arr2.schedule_stop_id
WHERE sr1.train_schedule_id = 527
  AND sr2.train_schedule_id = 527
  AND sr1.seat_id IS NOT NULL
  AND res1.reservation_status IN ('RESERVED', 'PURCHASED')
  AND res2.reservation_status IN ('RESERVED', 'PURCHASED')
  AND dep1.stop_order < arr2.stop_order
  AND arr1.stop_order > dep2.stop_order
  AND dep1.stop_order != arr2.stop_order
  AND dep2.stop_order != arr1.stop_order;
```
<img width="275" height="61" alt="image" src="https://github.com/user-attachments/assets/a63720f3-ad0d-4b00-93c5-c552c0f60a86" />

```
    HTTP
    http_req_duration.......................................................: avg=1.14s min=93.67ms  med=1.11s max=4.44s  p(90)=1.78s p(95)=1.88s
      { expected_response:true }............................................: avg=1.06s min=106.2ms  med=1.02s max=4.44s  p(90)=1.77s p(95)=1.88s
    http_req_failed.........................................................: 66.76%  4651 out of 6966
    http_reqs...............................................................: 6966    114.91476/s
```
하지만 비관적 락 도입으로 데이터 정합성은 보장되었지만, 대량 트래픽 환경에서는 성능 저하 가능성이 있습니다.
추후에는 분산 락 적용, 좌석 단위의 세분화된 락 범위 설정 등을 통해 성능 개선을 고려하고 있습니다. 좋은 아이디어가 있다면 공유해주시면 감사하겠습니다!

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.