### PR TITLE
[FEATURE] 만료된 예약 삭제 로직 개선

### DIFF
--- a/src/main/java/com/sudo/railo/booking/application/ReservationScheduler.java
+++ b/src/main/java/com/sudo/railo/booking/application/ReservationScheduler.java
@@ -11,7 +11,7 @@ public class ReservationScheduler {
 
 	private final ReservationService reservationService;
 
-	@Scheduled(cron = "0 * * * * *") // 매 분마다 실행
+	@Scheduled(cron = "0 0 * * * *") // 매 시간마다 실행
 	public void expireReservations() {
 		try {
 			reservationService.expireReservations();

--- a/src/main/java/com/sudo/railo/booking/application/ReservationService.java
+++ b/src/main/java/com/sudo/railo/booking/application/ReservationService.java
@@ -4,8 +4,11 @@ import java.math.BigDecimal;
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,27 +56,7 @@ public class ReservationService {
 	private final ReservationRepositoryCustom reservationRepositoryCustom;
 	private final SeatRepository seatRepository;
 
-	/***
-	 * 고객용 예매번호를 생성하는 메서드
-	 * @return 고객용 예매번호
-	 */
-	private String generateReservationCode() {
-		// yyyyMMddHHmmss<랜덤4자리> 형식
-		LocalDateTime now = LocalDateTime.now();
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-		String dateTimeStr = now.format(formatter);
-
-		String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-		StringBuilder randomStr = new StringBuilder();
-		SecureRandom secureRandom = new SecureRandom();
-		for (int i = 0; i < 4; i++) {
-			int idx = secureRandom.nextInt(chars.length());
-			randomStr.append(chars.charAt(idx));
-		}
-		return dateTimeStr + randomStr;
-	}
-
-	/***
+	/**
 	 * 예약을 생성하는 메서드
 	 * @param request 예약 생성 요청 DTO
 	 * @return 예약 레코드
@@ -148,35 +131,13 @@ public class ReservationService {
 		return carTypes.get(0);
 	}
 
-	/***
-	 * 예약 번호로 예약을 삭제하는 메서드
-	 * @param request 예약 삭제 요청 DTO
-	 */
-	@Transactional
-	public void deleteReservation(ReservationDeleteRequest request) {
-		try {
-			reservationRepository.deleteById(request.reservationId());
-		} catch (Exception e) {
-			throw new BusinessException(BookingError.RESERVATION_DELETE_FAILED);
-		}
-	}
-
-	/***
-	 * 만료된 예약을 일괄삭제하는 메서드
-	 */
-	@Transactional
-	public void expireReservations() {
-		LocalDateTime now = LocalDateTime.now();
-		reservationRepository.deleteAllByExpiresAtBeforeAndReservationStatusNot(now, ReservationStatus.PAID);
-	}
-
 	/**
 	 * 예약을 조회하는 메서드
 	 * @param memberNo 회원 번호
 	 * @param reservationId 예약 ID
 	 * @return 예약
 	 */
-	@Transactional(readOnly = true)
+	@Transactional
 	public ReservationDetail getReservation(String memberNo, Long reservationId) {
 		Member member = memberRepository.findByMemberNo(memberNo)
 			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
@@ -188,7 +149,16 @@ public class ReservationService {
 			throw new BusinessException(BookingError.RESERVATION_NOT_FOUND);
 		}
 
-		return convertToReservationDetail(reservationInfos).get(0);
+		ReservationInfo reservationInfo = reservationInfos.get(0);
+
+		// 만료된 예약이면 삭제 처리
+		LocalDateTime now = LocalDateTime.now();
+		if (isExpired(reservationInfo, now)) {
+			deleteReservation(reservationId);
+			throw new BusinessException(BookingError.RESERVATION_EXPIRED);
+		}
+
+		return convertToReservationDetail(reservationInfo);
 	}
 
 	/**
@@ -196,33 +166,136 @@ public class ReservationService {
 	 * @param memberNo 회원 번호
 	 * @return 예약 목록
 	 */
-	@Transactional(readOnly = true)
+	@Transactional
 	public List<ReservationDetail> getReservations(String memberNo) {
 		Member member = memberRepository.findByMemberNo(memberNo)
 			.orElseThrow(() -> new BusinessException(MemberError.USER_NOT_FOUND));
 
 		// 예약 조회
 		List<ReservationInfo> reservationInfos = reservationRepositoryCustom.findReservationDetail(member.getId());
-		return convertToReservationDetail(reservationInfos);
+
+		// 만료된 예약이면 삭제 처리
+		LocalDateTime now = LocalDateTime.now();
+		List<Long> expiredReservationIds = new ArrayList<>();
+		List<ReservationInfo> validReservations = reservationInfos.stream()
+			.filter(info -> {
+				if (isExpired(info, now)) {
+					expiredReservationIds.add(info.reservationId());
+					return false;
+				}
+				return true;
+			})
+			.toList();
+
+		if (!expiredReservationIds.isEmpty()) {
+			deleteReservation(expiredReservationIds);
+		}
+
+		return convertToReservationDetail(validReservations);
+	}
+
+	/**
+	 * 특정 예약을 삭제하는 메서드 - DTO 사용
+	 * @param request 예약 삭제 요청 DTO
+	 */
+	@Transactional
+	public void deleteReservation(ReservationDeleteRequest request) {
+		try {
+			reservationRepository.deleteById(request.reservationId());
+		} catch (Exception e) {
+			throw new BusinessException(BookingError.RESERVATION_DELETE_FAILED);
+		}
+	}
+
+	/**
+	 * 특정 예약을 삭제하는 메서드 - 단수 예약 ID 사용
+	 * @param reservationId 삭제할 예약의 ID
+	 */
+	@Transactional
+	public void deleteReservation(Long reservationId) {
+		reservationRepository.deleteById(reservationId);
+	}
+
+	/**
+	 * 다수의 예약을 삭제하는 메서드 - 복수 예약 ID 사용
+	 * @param reservationIds 삭제할 예약의 ID를 원소로 하는 리스트
+	 */
+	@Transactional
+	public void deleteReservation(List<Long> reservationIds) {
+		reservationRepository.deleteAllByIdInBatch(reservationIds);
+	}
+
+	/**
+	 * 만료된 예약을 일괄삭제하는 메서드
+	 */
+	@Transactional
+	public void expireReservations() {
+		LocalDateTime now = LocalDateTime.now();
+		Pageable pageable = PageRequest.of(0, 500);
+		List<Reservation> expiredReservations = reservationRepository
+			.findAllByExpiresAtBeforeAndReservationStatus(now, ReservationStatus.RESERVED, pageable);
+
+		if (expiredReservations.isEmpty())
+			return;
+
+		List<Long> expiredList = expiredReservations.stream()
+			.map(Reservation::getId)
+			.toList();
+
+		reservationRepository.deleteAllByIdInBatch(expiredList);
+	}
+
+	/**
+	 * 예약 정보와 주어진 시간을 기준으로 예약이 만료되었는지 판단하는 메서드
+	 * @param reservationInfo 예약 정보
+	 * @param now 판단 기준이 될 시간
+	 * @return 만료 여부
+	 */
+	private boolean isExpired(ReservationInfo reservationInfo, LocalDateTime now) {
+		return reservationInfo.expiresAt().isBefore(now);
+	}
+
+	/***
+	 * 고객용 예매번호를 생성하는 메서드
+	 * @return 고객용 예매번호
+	 */
+	private String generateReservationCode() {
+		// yyyyMMddHHmmss<랜덤4자리> 형식
+		LocalDateTime now = LocalDateTime.now();
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+		String dateTimeStr = now.format(formatter);
+
+		String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+		StringBuilder randomStr = new StringBuilder();
+		SecureRandom secureRandom = new SecureRandom();
+		for (int i = 0; i < 4; i++) {
+			int idx = secureRandom.nextInt(chars.length());
+			randomStr.append(chars.charAt(idx));
+		}
+		return dateTimeStr + randomStr;
 	}
 
 	public List<ReservationDetail> convertToReservationDetail(List<ReservationInfo> reservationInfos) {
 		return reservationInfos.stream()
-			.map(info -> ReservationDetail.of(
-				info.reservationId(),
-				info.reservationCode(),
-				String.format("%03d", info.trainNumber()),
-				info.trainName(),
-				info.departureStationName(),
-				info.arrivalStationName(),
-				info.departureTime(),
-				info.arrivalTime(),
-				info.operationDate(),
-				info.expiresAt(),
-				info.fare(),
-				convertToSeatReservationDetail(info.seats())
-			))
+			.map(this::convertToReservationDetail)
 			.toList();
+	}
+
+	public ReservationDetail convertToReservationDetail(ReservationInfo reservationInfo) {
+		return ReservationDetail.of(
+			reservationInfo.reservationId(),
+			reservationInfo.reservationCode(),
+			String.format("%03d", reservationInfo.trainNumber()),
+			reservationInfo.trainName(),
+			reservationInfo.departureStationName(),
+			reservationInfo.arrivalStationName(),
+			reservationInfo.departureTime(),
+			reservationInfo.arrivalTime(),
+			reservationInfo.operationDate(),
+			reservationInfo.expiresAt(),
+			reservationInfo.fare(),
+			convertToSeatReservationDetail(reservationInfo.seats())
+		);
 	}
 
 	private List<SeatReservationDetail> convertToSeatReservationDetail(List<SeatReservationProjection> projection) {

--- a/src/main/java/com/sudo/railo/booking/application/ReservationService.java
+++ b/src/main/java/com/sudo/railo/booking/application/ReservationService.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -231,18 +232,22 @@ public class ReservationService {
 	@Transactional
 	public void expireReservations() {
 		LocalDateTime now = LocalDateTime.now();
-		Pageable pageable = PageRequest.of(0, 500);
-		List<Reservation> expiredReservations = reservationRepository
-			.findAllByExpiresAtBeforeAndReservationStatus(now, ReservationStatus.RESERVED, pageable);
-
-		if (expiredReservations.isEmpty())
-			return;
-
-		List<Long> expiredList = expiredReservations.stream()
-			.map(Reservation::getId)
-			.toList();
-
-		reservationRepository.deleteAllByIdInBatch(expiredList);
+		int pageNumber = 0;
+		final int pageSize = 500;
+		Page<Reservation> expiredPage;
+		do {
+			Pageable pageable = PageRequest.of(pageNumber, pageSize);
+			expiredPage = reservationRepository
+				.findAllByExpiresAtBeforeAndReservationStatus(now, ReservationStatus.RESERVED, pageable);
+			if (expiredPage.hasContent()) {
+				List<Long> expiredList = expiredPage.getContent()
+					.stream()
+					.map(Reservation::getId)
+					.toList();
+				reservationRepository.deleteAllByIdInBatch(expiredList);
+			}
+			pageNumber++;
+		} while (expiredPage.hasNext());
 	}
 
 	/**

--- a/src/main/java/com/sudo/railo/booking/exception/BookingError.java
+++ b/src/main/java/com/sudo/railo/booking/exception/BookingError.java
@@ -26,6 +26,7 @@ public enum BookingError implements ErrorCode {
 	QR_CREATE_FAILED("QR 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_013"),
 	TICKET_CREATE_FAILED("티켓 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_014"),
 	TICKET_LIST_GET_FAILED("티켓을 가져올 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_015"),
+	RESERVATION_EXPIRED("예약이 만료되었습니다.", HttpStatus.GONE, "B_017"),
 
 	// 예약 요청 Request 관련
 	INVALID_CAR_TYPE("좌석의 객차 타입은 동일해야 합니다.", HttpStatus.BAD_REQUEST, "B_016"),

--- a/src/main/java/com/sudo/railo/booking/infrastructure/reservation/ReservationRepository.java
+++ b/src/main/java/com/sudo/railo/booking/infrastructure/reservation/ReservationRepository.java
@@ -1,13 +1,18 @@
 package com.sudo.railo.booking.infrastructure.reservation;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sudo.railo.booking.domain.Reservation;
 import com.sudo.railo.booking.domain.status.ReservationStatus;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-	void deleteAllByExpiresAtBeforeAndReservationStatusNot(LocalDateTime expiresAtBefore,
-		ReservationStatus reservationStatus);
+	List<Reservation> findAllByExpiresAtBeforeAndReservationStatus(
+		LocalDateTime expiresAtBefore,
+		ReservationStatus reservationStatus,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/sudo/railo/booking/infrastructure/reservation/ReservationRepository.java
+++ b/src/main/java/com/sudo/railo/booking/infrastructure/reservation/ReservationRepository.java
@@ -1,8 +1,8 @@
 package com.sudo.railo.booking.infrastructure.reservation;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,7 +10,7 @@ import com.sudo.railo.booking.domain.Reservation;
 import com.sudo.railo.booking.domain.status.ReservationStatus;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-	List<Reservation> findAllByExpiresAtBeforeAndReservationStatus(
+	Page<Reservation> findAllByExpiresAtBeforeAndReservationStatus(
 		LocalDateTime expiresAtBefore,
 		ReservationStatus reservationStatus,
 		Pageable pageable


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #165

## 주요 변경 사항 (필수)
<!-- 변경사항을 리스트 형식으로 입력해주세요. -->
- 예약 삭제 로직 수정

## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
### 예약 삭제 로직 변경
기존: 1분마다 만료된 로직을 찾고 삭제
변경: 예약 조회 시 만료된 로직을 삭제하고 유효한 예약만 반환, 1시간마다 조회에 의해 삭제되지 않은 예약을 찾아 자동 삭제

또한 스케줄러에 의해 삭제 시 많은 데이터에 의한 성능 부하를 줄이기 위해 500개씩 나눠서 삭제합니다. (`Pageable` 사용)

### `convertToReservationDetail` 메서드 수정
로직은 변경되지 않았습니다.
특정 예약 하나를 조회하는 메서드에서 `reservationInfo` 하나를 가져오기 위해
`convertToReservationDetail` 메서드의 반환값인 리스트에서 `get()` 메서드를 사용합니다.
그리고 마지막 반환 시 한번 더 `reservationInfos`를 인자로 하여 `get()` 메서드를 호출해야하는 구조입니다.
단수의 `reservationInfo`를 다룰 수 있게 기존 `convertToReservationDetail` 메서드를 오버로딩하여
단수, 복수개의 `reservationInfo` 모두 커버할 수 있도록 했습니다.

---

한번에 최대 몇개까지 검색해야할지, 시간은 어느정도로 해야하는지 이야기해보면 좋을것같습니다!

## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
- [x] 리뷰어를 지정했습니다.
- [x] 프로젝트를 연결했습니다.